### PR TITLE
Compile on OS X and FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+UNAME = $(shell sh -c 'uname -s 2>/dev/null || echo not')
 DESTDIR =
 PREFIX = /usr/local
 
@@ -10,9 +11,15 @@ CC = gcc
 DEBUG = -g
 OPTIM = -O3
 CFLAGS += $(DEBUG) $(OPTIM) -Wall -Wformat-security -Wno-format-zero-length
-LDFLAGS += -shared -Wl,-soname,$(LIB).$(MAJOR).$(MINOR)
+LDFLAGS += -shared
 LIBPATH += -L.
+
+ifeq ($(UNAME),Darwin)
+LDFLAGS += -Wl,-install_name,$(LIB).$(MAJOR).$(MINOR)
+else
+LDFLAGS += -Wl,-soname,$(LIB).$(MAJOR).$(MINOR)
 LIBS = -lcrypt
+endif
 
 all: $(LIB) clitest
 

--- a/clitest.c
+++ b/clitest.c
@@ -4,6 +4,7 @@
 #include <winsock2.h>
 #include <windows.h>
 #else
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #endif

--- a/libcli.c
+++ b/libcli.c
@@ -9,7 +9,9 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <memory.h>
+#if !defined(__APPLE__)
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <ctype.h>
 #include <unistd.h>

--- a/libcli.c
+++ b/libcli.c
@@ -9,7 +9,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <memory.h>
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
 #include <malloc.h>
 #endif
 #include <string.h>


### PR DESCRIPTION
Tweaks a few header file includes and Makefile rules to permit building libcli on Mac OS X and FreeBSD.

The OS detection in the Makefile is GNU Make specific and does not appear to function in BSD Make, this shouldn't be a problem though as gmake is available to FreeBSD via its ports tree.

I'm not terribly certain of the implications of the OS definition at the top of the Makefile for Windows hosts, I don't have one with a toolchain on to test with unfortunately.
