### PR TITLE
Fix build failure with GCC 5

### DIFF
--- a/clitest.c
+++ b/clitest.c
@@ -72,7 +72,7 @@ int winsock_init()
 int cmd_test(struct cli_def *cli, const char *command, char *argv[], int argc)
 {
     int i;
-    cli_print(cli, "called %s with \"%s\"", __FUNCTION__, command);
+    cli_print(cli, "called %s with \"%s\"", __func__, command);
     cli_print(cli, "%d arguments:", argc);
     for (i = 0; i < argc; i++)
         cli_print(cli, "        %s", argv[i]);


### PR DESCRIPTION
The error is:

```
clitest.c: In function ‘cmd_test’:
clitest.c:75:45: error: ISO C does not support '__FUNCTION__' predefined identifier [-Werror=pedantic]
     cli_print(cli, "called %s with \"%s\"", __FUNCTION__, command);
                                             ^
```

Fixed by using `__func__` from C99.
