### PR TITLE
FDG composite updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ $(LIB_STATIC): libcli.o
 libcli.o: libcli.h
 
 clitest: clitest.o $(LIB)
-	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $< -L. -lcli
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $< libcli.c -lcrypt
 
 clitest.exe: clitest.c libcli.o
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $< libcli.o -lws2_32

--- a/clitest.c
+++ b/clitest.c
@@ -98,7 +98,7 @@ int cmd_set(struct cli_def *cli, UNUSED(const char *command), char *argv[],
     if (strcmp(argv[0], "regular_interval") == 0)
     {
         unsigned int sec = 0;
-        if (!argv[1] && !&argv[1])
+        if (!argv[1] && !*argv[1])
         {
             cli_print(cli, "Specify a regular callback interval in seconds");
             return CLI_OK;
@@ -288,7 +288,11 @@ int main()
         perror("socket");
         return 1;
     }
-    setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+    
+    if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)))
+    { 
+        perror("setsockopt");
+    }
 
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;

--- a/libcli.c
+++ b/libcli.c
@@ -379,13 +379,20 @@ struct cli_command *cli_register_command(struct cli_def *cli, struct cli_command
     c->callback = callback;
     c->next = NULL;
     if (!(c->command = strdup(command)))
-        return NULL;
+    {
+        free(c);
+	return NULL;
+    }
+    
     c->parent = parent;
     c->privilege = privilege;
     c->mode = mode;
     if (help && !(c->help = strdup(help)))
-        return NULL;
-
+    {    free(c->command);
+	free(c);
+	return NULL;
+    }
+    
     if (parent)
     {
         if (!parent->children)
@@ -1209,7 +1216,10 @@ int cli_loop(struct cli_def *cli, int sockfd)
     cli->client->_file = sockfd;
 #else
     if (!(cli->client = fdopen(sockfd, "w+")))
-        return CLI_ERROR;
+    {
+        free(cmd);
+	return CLI_ERROR;
+    }
 #endif
 
     setbuf(cli->client, NULL);

--- a/libcli.c
+++ b/libcli.c
@@ -1495,16 +1495,25 @@ int cli_loop(struct cli_def *cli, int sockfd)
                         else
                         {
                             int i;
-                            cursor--;
+
                             if (cli->state != STATE_PASSWORD && cli->state != STATE_ENABLE_PASSWORD)
                             {
-                                for (i = cursor; i <= l; i++) cmd[i] = cmd[i+1];
+                                // back up one space, then write current buffer followed by a space
                                 _write(sockfd, "\b", 1);
-                                _write(sockfd, cmd + cursor, strlen(cmd + cursor));
+                                _write(sockfd, cmd+cursor, l-cursor);
                                 _write(sockfd, " ", 1);
-                                for (i = 0; i <= (int)strlen(cmd + cursor); i++)
-                                    _write(sockfd, "\b", 1);
+                                
+                                // move everything one char left
+                                memmove(cmd+cursor-1, cmd+cursor, l-cursor);
+                                
+                                //set former last char to null
+                                cmd[l-1]=0;
+                                
+                                // and reposition cursor
+                                for (i=l; i>= cursor; i--) _write(sockfd, "\b",1);
+                                
                             }
+                            cursor--;
                         }
                         l--;
                     }

--- a/libcli.c
+++ b/libcli.c
@@ -1179,7 +1179,7 @@ int cli_loop(struct cli_def *cli, int sockfd)
 {
     unsigned char c;
     int n, l, oldl = 0, is_telnet_option = 0, skip = 0, esc = 0;
-    int cursor = 0, insertmode = 1;
+    int cursor = 0;
     char *cmd = NULL, *oldcmd = 0;
     char *username = NULL, *password = NULL;
 
@@ -1786,25 +1786,29 @@ int cli_loop(struct cli_def *cli, int sockfd)
             else
             {
                 // Middle of text
-                if (insertmode)
-                {
-                    int i;
-                    // Move everything one character to the right
-                    if (l >= CLI_MAX_LINE_LENGTH - 2) l--;
-                    for (i = l; i >= cursor; i--)
-                        cmd[i + 1] = cmd[i];
-                    // Write what we've just added
-                    cmd[cursor] = c;
+                int i;
+                // Move everything one character to the right
+                memmove(cmd+cursor+1, cmd+cursor, l-cursor);
 
-                    _write(sockfd, &cmd[cursor], l - cursor + 1);
-                    for (i = 0; i < (l - cursor + 1); i++)
-                        _write(sockfd, "\b", 1);
-                    l++;
+                // Insert new character
+                cmd[cursor] = c;
+
+                // IMPORTANT - if at end of buffer, set last char to NULL and don't change length
+                // otherwise bump length by 1
+                if (l == CLI_MAX_LINE_LENGTH-1 ) 
+                {
+                    cmd[l]=0;
                 }
                 else
-                {
-                    cmd[cursor] = c;
+                { 
+                  l++;
                 }
+                    
+                // write buffer, then backspace to where we were
+                _write(sockfd, cmd+cursor, l-cursor);
+
+                for (i = 0; i < (l - cursor ); i++)
+                    _write(sockfd, "\b", 1);
                 cursor++;
             }
 

--- a/libcli.c
+++ b/libcli.c
@@ -161,10 +161,16 @@ static ssize_t _write(int fd, const void *buf, size_t count)
 }
 char *cli_command_name(struct cli_def *cli, struct cli_command *command)
 {
-    char *name = cli->commandname;
+    char *name;
     char *o;
 
-    if (name) free(name);
+    if (cli->commandname)
+    {
+      free(cli->commandname);
+      cli->commandname=NULL;
+    }
+    name=cli->commandname;
+
     if (!(name = calloc(1, 1)))
         return NULL;
 

--- a/libcli.c
+++ b/libcli.c
@@ -1770,15 +1770,17 @@ int cli_loop(struct cli_def *cli, int sockfd)
             /* normal character typed */
             if (cursor == l)
             {
-                 /* append to end of line */
-                cmd[cursor] = c;
+                 /* append to end of line if not at end-of-buffer */
                 if (l < CLI_MAX_LINE_LENGTH - 1)
                 {
+                    cmd[cursor] = c;
                     l++;
                     cursor++;
                 }
                 else
                 {
+		    // end-of-buffer, ensure null terminated
+                    cmd[cursor] = 0;
                     _write(sockfd, "\a", 1);
                     continue;
                 }

--- a/libcli.c
+++ b/libcli.c
@@ -1104,21 +1104,24 @@ out:
 
 static void cli_clear_line(int sockfd, char *cmd, int l, int cursor)
 {
-    int i;
-    if (cursor < l)
-    {
-        for (i = 0; i < (l - cursor); i++)
-            _write(sockfd, " ", 1);
-    }
-    for (i = 0; i < l; i++)
-        cmd[i] = '\b';
-    for (; i < l * 2; i++)
-        cmd[i] = ' ';
-    for (; i < l * 3; i++)
-        cmd[i] = '\b';
-    _write(sockfd, cmd, i);
-    memset((char *)cmd, 0, i);
-    l = cursor = 0;
+    // use cmd as our buffer, and overwrite contents as needed
+    // Backspace to beginning
+    memset((char*)cmd, '\b',cursor);
+    _write(sockfd, cmd, cursor);
+    
+    // overwrite existing cmd with spaces
+    memset((char*)cmd, ' ',l);
+    _write(sockfd, cmd, l);
+    
+    // and backspace again to beginning
+    memset((char*)cmd, '\b',l);
+    _write(sockfd, cmd, l);
+    
+    // null cmd buffer
+    memset((char *)cmd, 0, l);
+
+    // reset pointers to beginning
+    cursor = l = 0;
 }
 
 void cli_reprompt(struct cli_def *cli)

--- a/libcli.c
+++ b/libcli.c
@@ -630,9 +630,9 @@ void cli_unregister_all(struct cli_def *cli, struct cli_command *command)
 
 int cli_done(struct cli_def *cli)
 {
+    if (!cli) return CLI_OK;
     struct unp *u = cli->users, *n;
 
-    if (!cli) return CLI_OK;
     cli_free_history(cli);
 
     // Free all users


### PR DESCRIPTION
Found 4 bugs in cli_loop() or related processing that can result in buffer overrun/segfaults, which we've seen with our code when using libcli.  These are fixed, and also ran the code through Coverity and found 7 additional 'findings'.  2 of them were in the clitest.c harness, but I've fixed all 7.  One change I have not tested in part of the 'Fix_varargs usage' commit, in the asprintf() function for WIN32.  We are in a RHEL7 environment.