### PR TITLE
Optargs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ DESTDIR =
 PREFIX = /usr/local
 
 MAJOR = 1
-MINOR = 9
-REVISION = 8
+MINOR = 10
+REVISION = 0
 LIB = libcli.so
 LIB_STATIC = libcli.a
 

--- a/README.md
+++ b/README.md
@@ -1,112 +1,111 @@
-libcli
+Libcli provides a shared C library for including a Cisco-like command-line
+interface into other software.
 
-libcli emulates a cisco style telnet command-line interface.
+It’s a telnet interface which supports command-line editing, history,
+authentication and callbacks for a user-definable function tree.
 
 To compile:
 
-	make
-	make install
+```sh
+$ make
+$ make install
+```
 
-This will install libcli.so into /usr/local/lib. If you want to change
-the location, edit Makefile.
+This will install `libcli.so` into `/usr/local/lib`. If you want to change the
+location, edit Makefile.
 
-There is a test application built called clitest. Run this and telnet
-to port 8000.
+There is a test application built called clitest. Run this and telnet to port
+8000.
 
 By default, a single username and password combination is enabled.
 
+```
 Username: fred
 Password: nerk
+```
 
-Get help by entering "help" or hitting ?.
+Get help by entering `help` or hitting `?`.
 
 libcli provides support for using the arrow keys for command-line editing. Up
 and Down arrows will cycle through the command history, and Left & Right can be
 used for editing the current command line.
+
 libcli also works out the shortest way of entering a command, so if you have a
-command "show users grep foobar" defined, you can enter "sh us g foobar" if that
+command `show users | grep foobar` defined, you can enter `sh us | g foobar` if that
 is the shortest possible way of doing it.
 
-Enter "sh?" at the command line to get a list of commands starting with "sh"
+Enter `sh?` at the command line to get a list of commands starting with `sh`
 
 A few commands are defined in every libcli program:
-help
-quit
-exit
-logout
-history
 
-
-
+* `help`
+* `quit`
+* `exit`
+* `logout`
+* `history`
 
 Use in your own code:
 
-First of all, make sure you #include <libcli.h> in your C code, and link
-with -lcli.
+First of all, make sure you `#include <libcli.h>` in your C code, and link with
+`-lcli`.
 
 If you have any trouble with this, have a look at clitest.c for a
 demonstration.
 
-Start your program off with a cli_init().
+Start your program off with a `cli_init()`.
 This sets up the internal data structures required.
 
 When a user connects, they are presented with a greeting if one is set using the
-cli_set_banner(banner) function.
-
+`cli_set_banner(banner)` function.
 
 By default, the command-line session is not authenticated, which means users
 will get full access as soon as they connect. As this may not be always the best
 thing, 2 methods of authentication are available.
 
 First, you can add username / password combinations with the
-cli_allow_user(username, password) function. When a user connects, they can
+`cli_allow_user(username, password)` function. When a user connects, they can
 connect with any of these username / password combinations.
 
-Secondly, you can add a callback using the cli_set_auth_callback(callback)
-function. This function is passed the username and password as char *, and must
-return CLI_OK if the user is to have access and CLI_ERROR if they are not.
+Secondly, you can add a callback using the `cli_set_auth_callback(callback)`
+function. This function is passed the username and password as `char *`, and must
+return `CLI_OK` if the user is to have access and `CLI_ERROR` if they are not.
 
 The library itself will take care of prompting the user for credentials.
 
-
-
-
 Commands are built using a tree-like structure. You define commands with the
-cli_register_command(parent, command, callback, privilege, mode, help) function.
+`cli_register_command(parent, command, callback, privilege, mode, help)` function.
 
-parent is a cli_command * reference to a previously added command. Using a
+`parent` is a `cli_command *` reference to a previously added command. Using a
 parent you can build up complex commands.
-e.g. to provide commands "show users", "show sessions" and "show people", use
+
+e.g. to provide commands `show users`, `show sessions` and `show people`, use
 the following sequence:
 
+```c
 cli_command *c = cli_register_command(NULL, "show", NULL, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
 cli_register_command(c, "sessions", fn_sessions, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Show the sessions connected");
 cli_register_command(c, "users", fn_users, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Show the users connected");
 cli_register_command(c, "people", fn_people, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Show a list of the people I like");
+```
 
-
-If callback is NULL, the command can be used as part of a tree, but cannot be
+If callback is `NULL`, the command can be used as part of a tree, but cannot be
 individually run. 
 
-
 If you decide later that you don't want a command to be run, you can call
-cli_unregister_command(command).
+`cli_unregister_command(command)`.
 You can use this to build dynamic command trees.
 
-
 It is possible to carry along a user-defined context to all command callbacks
-using cli_set_context(cli, context) and cli_get_context(cli) functions.
+using `cli_set_context(cli, context)` and `cli_get_context(cli)` functions.
 
 
 You are responsible for accepting a TCP connection, and for creating a
 process or thread to run the cli.  Once you are ready to process the
-connection, call cli_loop(cli, sock) to interact with the user on the
+connection, call `cli_loop(cli, sock)` to interact with the user on the
 given socket.
 
 This function will return when the user exits the cli, either by breaking the
-connection or entering "quit".
+connection or entering `quit`.
 
-Call cli_done() to free the data structures.
+Call `cli_done()` to free the data structures.
 
-
-- David Parrish (david@dparrish.com)

--- a/clitest.c
+++ b/clitest.c
@@ -183,11 +183,21 @@ int cmd_perimeter( struct cli_def *cli, const char *command, char *argv[], int a
   struct cli_optarg_pair *optargs=cli_get_all_found_optargs(cli);
   int i=1,numSides=0;
   int perimeter=0;
+  int verbose_count=0;
+  char *verboseArg=NULL;
   char *shapeName=NULL;
 
   cli_print(cli, "perimeter callback, with %d args" , argc);
   for (;optargs;optargs=optargs->next) 
     cli_print(cli, "%d, %s=%s", i++, optargs->name, optargs->value);
+  
+  
+  if ((verboseArg=cli_get_optarg_value(cli, "verbose", verboseArg))) {
+    do {
+      verbose_count++;
+    } while ((verboseArg=cli_get_optarg_value(cli, "verbose", verboseArg)));
+  }
+  cli_print(cli, "verbose argument was seen  %d times", verbose_count);
   
   shapeName = cli_get_optarg_value(cli, "shape", NULL);
   if (!shapeName) {
@@ -215,12 +225,12 @@ int cmd_perimeter( struct cli_def *cli, const char *command, char *argv[], int a
 
 const char *KnownShapes[] = {"rectangle","triangle", NULL};
 
-int shape_completor(struct cli_def *cli, const char *name, const char *word, struct cli_comphelp *comphelp) {
+int shape_completor(struct cli_def *cli, const char *name, const char *value, struct cli_comphelp *comphelp) {
   const char **shape ;
   int rc=CLI_OK;
-  printf ("Calling shape_completor given %s" , word);
+  printf("shape_completor called with <%s>\n", value);
   for (shape=KnownShapes; *shape && (rc==CLI_OK);shape++) {
-    if (!word || !strncmp(*shape, word, strlen(word))) {
+    if (!value || !strncmp(*shape, value, strlen(value))) {
       rc=cli_add_comphelp_entry(comphelp, *shape);
     }
   }
@@ -230,14 +240,22 @@ int shape_completor(struct cli_def *cli, const char *name, const char *word, str
 int shape_validator(struct cli_def *cli, const char *name, const char *value) {
   const char **shape;
   int rc=CLI_ERROR;
+  printf("shape_validator called with <%s>\n", value);
   for (shape=KnownShapes; *shape; shape++) {
     if (!strcmp(value, *shape)) return CLI_OK;
   }
   return rc;
 }
 
+int verbose_validator(struct cli_def *cli, const char *name, const char *value) {
+  int rc=CLI_OK;
+  printf ("verbose_validator called\n");
+  return rc;
+}
+
 int shape_transient_eval( struct cli_def *cli, const char *name, const char *value) {
   int rc=CLI_OK;
+  printf("shape_transient_eval called with <%s>\n", value);
   if ( !strcmp(value,"rectangle")) {
     cli_set_transient_mode(cli, MODE_POLYGON_RECTANGLE);
     rc=CLI_OK;
@@ -258,6 +276,7 @@ int color_completor(struct cli_def *cli, const char *name, const char *word, str
   // Attempt to show matches against the following color strings
   const char **color ;
   int rc=CLI_OK;
+  printf("color_completor called with <%s>\n", word);
   for (color=KnownColors; *color && (rc==CLI_OK);color++) {
     if (!word || !strncmp(*color, word, strlen(word))) {
       rc=cli_add_comphelp_entry(comphelp, *color);
@@ -269,6 +288,7 @@ int color_completor(struct cli_def *cli, const char *name, const char *word, str
 int color_validator(struct cli_def *cli, const char *name, const char *value) {
   const char **color;
   int rc=CLI_ERROR;
+  printf("color_validator called for %s\n", name);
   for (color=KnownColors; *color; color++) {
     if (!strcmp(value, *color)) return CLI_OK;
   }
@@ -281,6 +301,7 @@ int side_length_validator(struct cli_def *cli, const char *name, const char *val
   char *endptr;
   int rc = CLI_OK;
   
+  printf("side_length_validator called\n");
   errno=0;
   len = strtol (value, &endptr, 10);
   if ((endptr==value) || (*endptr != '\0') ||  ((errno==ERANGE) && ((len == LONG_MIN) || (len == LONG_MAX))) )return CLI_ERROR;
@@ -327,6 +348,8 @@ void run_child(int x) {
   
   c=cli_register_command(cli, NULL, "perimeter", cmd_perimeter, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Calculate perimeter of polygon");
   cli_register_optarg(c, "transparent", CLI_CMD_OPTIONAL_FLAG, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Set transparent flag",
+  	NULL, NULL, NULL);
+  cli_register_optarg(c, "verbose", CLI_CMD_OPTIONAL_FLAG|CLI_CMD_OPTION_MULTIPLE, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Set transparent flag",
   	NULL, NULL, NULL);
   cli_register_optarg(c, "shape", CLI_CMD_ARGUMENT|CLI_CMD_ALLOW_BUILDMODE, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Specify shape to calclate perimeter for",
   	shape_completor, shape_validator, shape_transient_eval);

--- a/clitest.c
+++ b/clitest.c
@@ -304,6 +304,24 @@ int side_length_validator(struct cli_def *cli, const char *name, const char *val
   return rc;
 }
 
+int check1_validator(struct cli_def *cli, UNUSED(const char *name), UNUSED(const char *value)) {
+  char *color;
+  char *transparent;
+  
+  printf("check1_validator called \n");
+  color = cli_get_optarg_value(cli, "color", NULL);
+  transparent = cli_get_optarg_value(cli, "transparent", NULL);
+  
+  if (!color && !transparent) {
+    cli_error(cli,"\nMust supply either a color or transparent!");
+    return CLI_ERROR;
+  } else if (color && !strcmp(color,"black") && transparent) {
+    cli_error(cli, "\nCan not have a transparent black object!");
+    return CLI_ERROR;
+  }
+  return CLI_OK;
+}
+
 void run_child(int x) {
   struct cli_command *c;
   struct cli_def *cli;
@@ -352,11 +370,14 @@ void run_child(int x) {
                       "Set transparent flag", NULL, NULL, NULL);
   cli_register_optarg(c, "verbose", CLI_CMD_OPTIONAL_FLAG | CLI_CMD_OPTION_MULTIPLE, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
                       "Set transparent flag", NULL, NULL, NULL);
+  cli_register_optarg(c, "color", CLI_CMD_OPTIONAL_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Set color",
+                      color_completor, color_validator, NULL);
+  cli_register_optarg(c, "__check1__", CLI_CMD_SPOT_CHECK,PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
+                      NULL, NULL, check1_validator,
+                      NULL);  
   cli_register_optarg(c, "shape", CLI_CMD_ARGUMENT | CLI_CMD_ALLOW_BUILDMODE, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
                       "Specify shape to calclate perimeter for", shape_completor, shape_validator,
                       shape_transient_eval);
-  cli_register_optarg(c, "color", CLI_CMD_OPTIONAL_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Set color",
-                      color_completor, color_validator, NULL);
   cli_register_optarg(c, "side_1", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_TRIANGLE,
                       "Specify side 1 length", NULL, side_length_validator, NULL);
   cli_register_optarg(c, "side_1", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_RECTANGLE,

--- a/clitest.c
+++ b/clitest.c
@@ -1,7 +1,7 @@
-#include <stdio.h>
-#include <sys/types.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdio.h>
+#include <sys/types.h>
 #ifdef WIN32
 #include <windows.h>
 #include <winsock2.h>
@@ -163,14 +163,18 @@ int regular_callback(struct cli_def *cli) {
   return CLI_OK;
 }
 
-int check_enable(const char *password) { return !strcasecmp(password, "topsecret"); }
+int check_enable(const char *password) {
+  return !strcasecmp(password, "topsecret");
+}
 
 int idle_timeout(struct cli_def *cli) {
   cli_print(cli, "Custom idle timeout");
   return CLI_QUIT;
 }
 
-void pc(UNUSED(struct cli_def *cli), const char *string) { printf("%s\n", string); }
+void pc(UNUSED(struct cli_def *cli), const char *string) {
+  printf("%s\n", string);
+}
 
 #define MODE_POLYGON_TRIANGLE 20
 #define MODE_POLYGON_RECTANGLE 21
@@ -233,34 +237,30 @@ int shape_completor(struct cli_def *cli, const char *name, const char *value, st
 
 int shape_validator(struct cli_def *cli, const char *name, const char *value) {
   const char **shape;
-  int rc = CLI_ERROR;
+
   printf("shape_validator called with <%s>\n", value);
   for (shape = KnownShapes; *shape; shape++) {
     if (!strcmp(value, *shape)) return CLI_OK;
   }
-  return rc;
+  return CLI_ERROR;
 }
 
 int verbose_validator(struct cli_def *cli, const char *name, const char *value) {
-  int rc = CLI_OK;
   printf("verbose_validator called\n");
-  return rc;
+  return CLI_OK;
 }
 
 int shape_transient_eval(struct cli_def *cli, const char *name, const char *value) {
-  int rc = CLI_OK;
   printf("shape_transient_eval called with <%s>\n", value);
   if (!strcmp(value, "rectangle")) {
     cli_set_transient_mode(cli, MODE_POLYGON_RECTANGLE);
-    rc = CLI_OK;
+    return CLI_OK;
   } else if (!strcmp(value, "triangle")) {
     cli_set_transient_mode(cli, MODE_POLYGON_TRIANGLE);
-    rc = CLI_OK;
-  } else {
-    cli_error(cli, "unrecognized value for setting %s -> %s", name, value);
-    rc = CLI_ERROR;
+    return CLI_OK;
   }
-  return rc;
+  cli_error(cli, "unrecognized value for setting %s -> %s", name, value);
+  return  CLI_ERROR;
 }
 
 const char *KnownColors[] = {"black",    "white",    "gray",      "red",        "blue",
@@ -319,8 +319,12 @@ void run_child(int x) {
   cli_set_hostname(cli, "router");
   cli_telnet_protocol(cli, 1);
   cli_regular(cli, regular_callback);
-  cli_regular_interval(cli, 5);  // Defaults to 1 second
-                                 //  cli_set_idle_timeout_callback(cli, 60, idle_timeout);  // 60 second idle timeout
+  
+  // change regular update to 5 seconds rather than default of 1 second
+  cli_regular_interval(cli, 5);
+  
+  // set 60 second idle timeout
+  cli_set_idle_timeout_callback(cli, 60, idle_timeout); 
   cli_register_command(cli, NULL, "test", cmd_test, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
   cli_register_command(cli, NULL, "simple", NULL, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
   cli_register_command(cli, NULL, "simon", NULL, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);

--- a/clitest.c
+++ b/clitest.c
@@ -163,75 +163,69 @@ int regular_callback(struct cli_def *cli) {
   return CLI_OK;
 }
 
-int check_enable(const char *password) {
-  return !strcasecmp(password, "topsecret");
-}
+int check_enable(const char *password) { return !strcasecmp(password, "topsecret"); }
 
 int idle_timeout(struct cli_def *cli) {
   cli_print(cli, "Custom idle timeout");
   return CLI_QUIT;
 }
 
-void pc(UNUSED(struct cli_def *cli), const char *string) {
-  printf("%s\n", string);
-}
+void pc(UNUSED(struct cli_def *cli), const char *string) { printf("%s\n", string); }
 
 #define MODE_POLYGON_TRIANGLE 20
 #define MODE_POLYGON_RECTANGLE 21
 
-int cmd_perimeter( struct cli_def *cli, const char *command, char *argv[], int argc) {
-  struct cli_optarg_pair *optargs=cli_get_all_found_optargs(cli);
-  int i=1,numSides=0;
-  int perimeter=0;
-  int verbose_count=0;
-  char *verboseArg=NULL;
-  char *shapeName=NULL;
+int cmd_perimeter(struct cli_def *cli, const char *command, char *argv[], int argc) {
+  struct cli_optarg_pair *optargs = cli_get_all_found_optargs(cli);
+  int i = 1, numSides = 0;
+  int perimeter = 0;
+  int verbose_count = 0;
+  char *verboseArg = NULL;
+  char *shapeName = NULL;
 
-  cli_print(cli, "perimeter callback, with %d args" , argc);
-  for (;optargs;optargs=optargs->next) 
-    cli_print(cli, "%d, %s=%s", i++, optargs->name, optargs->value);
-  
-  
-  if ((verboseArg=cli_get_optarg_value(cli, "verbose", verboseArg))) {
+  cli_print(cli, "perimeter callback, with %d args", argc);
+  for (; optargs; optargs = optargs->next) cli_print(cli, "%d, %s=%s", i++, optargs->name, optargs->value);
+
+  if ((verboseArg = cli_get_optarg_value(cli, "verbose", verboseArg))) {
     do {
       verbose_count++;
-    } while ((verboseArg=cli_get_optarg_value(cli, "verbose", verboseArg)));
+    } while ((verboseArg = cli_get_optarg_value(cli, "verbose", verboseArg)));
   }
   cli_print(cli, "verbose argument was seen  %d times", verbose_count);
-  
+
   shapeName = cli_get_optarg_value(cli, "shape", NULL);
   if (!shapeName) {
     cli_error(cli, "No shape name given");
     return CLI_ERROR;
-  } else if (strcmp(shapeName,"triangle") ==0 ) {
-    numSides=3;
-  } else if (strcmp(shapeName,"rectangle") == 0 ) {
-    numSides=4;
+  } else if (strcmp(shapeName, "triangle") == 0) {
+    numSides = 3;
+  } else if (strcmp(shapeName, "rectangle") == 0) {
+    numSides = 4;
   } else {
     cli_error(cli, "Unrecognized shape given");
     return CLI_ERROR;
   }
-  for (i=1;i<=numSides;i++) {
+  for (i = 1; i <= numSides; i++) {
     char sidename[50], *value;
     int length;
-    snprintf(sidename,50,"side_%d",i);
+    snprintf(sidename, 50, "side_%d", i);
     value = cli_get_optarg_value(cli, sidename, NULL);
-    length = strtol(value, NULL,10);
+    length = strtol(value, NULL, 10);
     perimeter += length;
   }
   cli_print(cli, "Perimeter is %d", perimeter);
   return CLI_OK;
 }
 
-const char *KnownShapes[] = {"rectangle","triangle", NULL};
+const char *KnownShapes[] = {"rectangle", "triangle", NULL};
 
 int shape_completor(struct cli_def *cli, const char *name, const char *value, struct cli_comphelp *comphelp) {
-  const char **shape ;
-  int rc=CLI_OK;
+  const char **shape;
+  int rc = CLI_OK;
   printf("shape_completor called with <%s>\n", value);
-  for (shape=KnownShapes; *shape && (rc==CLI_OK);shape++) {
+  for (shape = KnownShapes; *shape && (rc == CLI_OK); shape++) {
     if (!value || !strncmp(*shape, value, strlen(value))) {
-      rc=cli_add_comphelp_entry(comphelp, *shape);
+      rc = cli_add_comphelp_entry(comphelp, *shape);
     }
   }
   return rc;
@@ -239,47 +233,48 @@ int shape_completor(struct cli_def *cli, const char *name, const char *value, st
 
 int shape_validator(struct cli_def *cli, const char *name, const char *value) {
   const char **shape;
-  int rc=CLI_ERROR;
+  int rc = CLI_ERROR;
   printf("shape_validator called with <%s>\n", value);
-  for (shape=KnownShapes; *shape; shape++) {
+  for (shape = KnownShapes; *shape; shape++) {
     if (!strcmp(value, *shape)) return CLI_OK;
   }
   return rc;
 }
 
 int verbose_validator(struct cli_def *cli, const char *name, const char *value) {
-  int rc=CLI_OK;
-  printf ("verbose_validator called\n");
+  int rc = CLI_OK;
+  printf("verbose_validator called\n");
   return rc;
 }
 
-int shape_transient_eval( struct cli_def *cli, const char *name, const char *value) {
-  int rc=CLI_OK;
+int shape_transient_eval(struct cli_def *cli, const char *name, const char *value) {
+  int rc = CLI_OK;
   printf("shape_transient_eval called with <%s>\n", value);
-  if ( !strcmp(value,"rectangle")) {
+  if (!strcmp(value, "rectangle")) {
     cli_set_transient_mode(cli, MODE_POLYGON_RECTANGLE);
-    rc=CLI_OK;
+    rc = CLI_OK;
   } else if (!strcmp(value, "triangle")) {
     cli_set_transient_mode(cli, MODE_POLYGON_TRIANGLE);
-    rc=CLI_OK;
+    rc = CLI_OK;
   } else {
-    cli_error(cli, "unrecognized value for setting %s -> %s" , name, value);
-    rc=CLI_ERROR;
+    cli_error(cli, "unrecognized value for setting %s -> %s", name, value);
+    rc = CLI_ERROR;
   }
   return rc;
 }
 
-const char *KnownColors[] = {"black", "white","gray", "red","blue","green","lightred","lightblue","lightgreen",
-                 "darkred","darkblue","darkgree","lavender", "yellow", NULL};
+const char *KnownColors[] = {"black",    "white",    "gray",      "red",        "blue",
+                             "green",    "lightred", "lightblue", "lightgreen", "darkred",
+                             "darkblue", "darkgree", "lavender",  "yellow",     NULL};
 
 int color_completor(struct cli_def *cli, const char *name, const char *word, struct cli_comphelp *comphelp) {
   // Attempt to show matches against the following color strings
-  const char **color ;
-  int rc=CLI_OK;
+  const char **color;
+  int rc = CLI_OK;
   printf("color_completor called with <%s>\n", word);
-  for (color=KnownColors; *color && (rc==CLI_OK);color++) {
+  for (color = KnownColors; *color && (rc == CLI_OK); color++) {
     if (!word || !strncmp(*color, word, strlen(word))) {
-      rc=cli_add_comphelp_entry(comphelp, *color);
+      rc = cli_add_comphelp_entry(comphelp, *color);
     }
   }
   return rc;
@@ -287,9 +282,9 @@ int color_completor(struct cli_def *cli, const char *name, const char *word, str
 
 int color_validator(struct cli_def *cli, const char *name, const char *value) {
   const char **color;
-  int rc=CLI_ERROR;
+  int rc = CLI_ERROR;
   printf("color_validator called for %s\n", name);
-  for (color=KnownColors; *color; color++) {
+  for (color = KnownColors; *color; color++) {
     if (!strcmp(value, *color)) return CLI_OK;
   }
   return rc;
@@ -300,11 +295,12 @@ int side_length_validator(struct cli_def *cli, const char *name, const char *val
   long len;
   char *endptr;
   int rc = CLI_OK;
-  
+
   printf("side_length_validator called\n");
-  errno=0;
-  len = strtol (value, &endptr, 10);
-  if ((endptr==value) || (*endptr != '\0') ||  ((errno==ERANGE) && ((len == LONG_MIN) || (len == LONG_MAX))) )return CLI_ERROR;
+  errno = 0;
+  len = strtol(value, &endptr, 10);
+  if ((endptr == value) || (*endptr != '\0') || ((errno == ERANGE) && ((len == LONG_MIN) || (len == LONG_MAX))))
+    return CLI_ERROR;
   return rc;
 }
 
@@ -323,8 +319,8 @@ void run_child(int x) {
   cli_set_hostname(cli, "router");
   cli_telnet_protocol(cli, 1);
   cli_regular(cli, regular_callback);
-  cli_regular_interval(cli, 5);                          // Defaults to 1 second
-//  cli_set_idle_timeout_callback(cli, 60, idle_timeout);  // 60 second idle timeout
+  cli_regular_interval(cli, 5);  // Defaults to 1 second
+                                 //  cli_set_idle_timeout_callback(cli, 60, idle_timeout);  // 60 second idle timeout
   cli_register_command(cli, NULL, "test", cmd_test, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
   cli_register_command(cli, NULL, "simple", NULL, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
   cli_register_command(cli, NULL, "simon", NULL, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
@@ -345,32 +341,32 @@ void run_child(int x) {
                        "Enable cli_regular() callback debugging");
 
   // Register some commands/subcommands to demonstrate opt/arg and buildmode operations
-  
-  c=cli_register_command(cli, NULL, "perimeter", cmd_perimeter, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Calculate perimeter of polygon");
-  cli_register_optarg(c, "transparent", CLI_CMD_OPTIONAL_FLAG, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Set transparent flag",
-  	NULL, NULL, NULL);
-  cli_register_optarg(c, "verbose", CLI_CMD_OPTIONAL_FLAG|CLI_CMD_OPTION_MULTIPLE, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Set transparent flag",
-  	NULL, NULL, NULL);
-  cli_register_optarg(c, "shape", CLI_CMD_ARGUMENT|CLI_CMD_ALLOW_BUILDMODE, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Specify shape to calclate perimeter for",
-  	shape_completor, shape_validator, shape_transient_eval);
+
+  c = cli_register_command(cli, NULL, "perimeter", cmd_perimeter, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
+                           "Calculate perimeter of polygon");
+  cli_register_optarg(c, "transparent", CLI_CMD_OPTIONAL_FLAG, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
+                      "Set transparent flag", NULL, NULL, NULL);
+  cli_register_optarg(c, "verbose", CLI_CMD_OPTIONAL_FLAG | CLI_CMD_OPTION_MULTIPLE, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
+                      "Set transparent flag", NULL, NULL, NULL);
+  cli_register_optarg(c, "shape", CLI_CMD_ARGUMENT | CLI_CMD_ALLOW_BUILDMODE, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
+                      "Specify shape to calclate perimeter for", shape_completor, shape_validator,
+                      shape_transient_eval);
   cli_register_optarg(c, "color", CLI_CMD_OPTIONAL_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Set color",
-  	color_completor, color_validator, NULL);
-  cli_register_optarg(c, "side_1", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_TRIANGLE, "Specify side 1 length",
-  	NULL, side_length_validator, NULL);
-  cli_register_optarg(c, "side_1", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_RECTANGLE, "Specify side 1 length",
-  	NULL, side_length_validator, NULL);
-  cli_register_optarg(c, "side_2", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_TRIANGLE, "Specify side 2 length",
-  	NULL, side_length_validator, NULL);
-  cli_register_optarg(c, "side_2", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_RECTANGLE, "Specify side 2 length",
-  	NULL, side_length_validator, NULL);
-  cli_register_optarg(c, "side_3", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_TRIANGLE, "Specify side 3 length",
-  	NULL, side_length_validator, NULL);
-  cli_register_optarg(c, "side_3", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_RECTANGLE, "Specify side 3 length",
-  	NULL, side_length_validator, NULL);
-  cli_register_optarg(c, "side_4", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_RECTANGLE, "Specify side 4 length",
-  	NULL, side_length_validator, NULL);
-	
-  
+                      color_completor, color_validator, NULL);
+  cli_register_optarg(c, "side_1", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_TRIANGLE,
+                      "Specify side 1 length", NULL, side_length_validator, NULL);
+  cli_register_optarg(c, "side_1", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_RECTANGLE,
+                      "Specify side 1 length", NULL, side_length_validator, NULL);
+  cli_register_optarg(c, "side_2", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_TRIANGLE,
+                      "Specify side 2 length", NULL, side_length_validator, NULL);
+  cli_register_optarg(c, "side_2", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_RECTANGLE,
+                      "Specify side 2 length", NULL, side_length_validator, NULL);
+  cli_register_optarg(c, "side_3", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_TRIANGLE,
+                      "Specify side 3 length", NULL, side_length_validator, NULL);
+  cli_register_optarg(c, "side_3", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_RECTANGLE,
+                      "Specify side 3 length", NULL, side_length_validator, NULL);
+  cli_register_optarg(c, "side_4", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_RECTANGLE,
+                      "Specify side 4 length", NULL, side_length_validator, NULL);
 
   // Set user context and its command
   cli_set_context(cli, (void *)&myctx);
@@ -391,7 +387,7 @@ void run_child(int x) {
       fclose(fh);
     }
   }
-  cli_loop(cli,x);
+  cli_loop(cli, x);
   cli_done(cli);
 }
 

--- a/clitest.c
+++ b/clitest.c
@@ -260,7 +260,7 @@ int shape_transient_eval(struct cli_def *cli, const char *name, const char *valu
     return CLI_OK;
   }
   cli_error(cli, "unrecognized value for setting %s -> %s", name, value);
-  return  CLI_ERROR;
+  return CLI_ERROR;
 }
 
 const char *KnownColors[] = {"black",    "white",    "gray",      "red",        "blue",
@@ -319,12 +319,12 @@ void run_child(int x) {
   cli_set_hostname(cli, "router");
   cli_telnet_protocol(cli, 1);
   cli_regular(cli, regular_callback);
-  
+
   // change regular update to 5 seconds rather than default of 1 second
   cli_regular_interval(cli, 5);
-  
+
   // set 60 second idle timeout
-  cli_set_idle_timeout_callback(cli, 60, idle_timeout); 
+  cli_set_idle_timeout_callback(cli, 60, idle_timeout);
   cli_register_command(cli, NULL, "test", cmd_test, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
   cli_register_command(cli, NULL, "simple", NULL, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
   cli_register_command(cli, NULL, "simon", NULL, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);

--- a/doc/developers-guide.md
+++ b/doc/developers-guide.md
@@ -1,0 +1,243 @@
+## Introduction
+libcli provides a telnet command-line environment which can be embedded in other programs. This environment includes useful features such as automatic authentication, history, and command-line editing.
+
+This guide should show you everything you need to embed libcli into your program. If you have any corrections, suggestions or modifications, please email [David Parrish](mailto:david+libcli@dparrish.com).
+
+## Authentication
+Two methods of authentcation are supported by libcli - internal and callback.
+
+Internal authentication is based on a list of username / password combinations that are set up before `cli_loop()` is called. Passwords may be clear text, MD5 encrypted, or DES encrypted (requires a `{crypt}` prefix to distinguish from clear text).
+
+Callback based authentication calls a callback with the username and password that the user enters, and must return either `CLI_OK` or `CLI_ERROR`. This can be used for checking passwords against some other database such as LDAP.
+
+If neither `cli_set_auth_callback()` or `cli_allow_user()` have been called before `cli_loop()`, then authentication will be disabled and the user will not be prompted for a username / password combination.
+
+Authentication for the privileged state can also be defined by a static password or by a callback. Use the `cli_set_enable_callback()` or `cli_allow_enable()` functions to set the enable password.
+
+## Tutorial
+This section will guide you through implementing libcli in a basic server.
+
+### Create a file libclitest.c
+
+```c
+#include <libcli.h>
+    
+int main(int argc, char *argv[]) {
+  struct sockaddr_in servaddr;
+  struct cli_command *c;
+  struct cli_def *cli;
+  int on = 1, x, s;
+
+  // Must be called first to setup data structures
+  cli = cli_init();
+
+  // Set the hostname (shown in the the prompt)
+  cli_set_hostname(cli, "test");
+
+  // Set the greeting
+  cli_set_banner(cli, "Welcome to the CLI test program.");
+
+  // Enable 2 username / password combinations
+  cli_allow_user(cli, "fred", "nerk");
+  cli_allow_user(cli, "foo", "bar");
+
+  // Set up a few simple one-level commands
+  cli_register_command(cli, NULL, "test", cmd_test, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
+  cli_register_command(cli, NULL, "simple", cmd_test, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
+  cli_register_command(cli, NULL, "simon", NULL, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
+
+  // This command takes arguments, and requires privileged mode (enable)
+  cli_register_command(cli, NULL, "set", cmd_set, PRIVILEGE_PRIVILEGED, MODE_EXEC, NULL);
+
+  // Set up 2 commands "show counters" and "show junk"
+  c = cli_register_command(cli, NULL, "show", NULL, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
+  // Note how we store the previous command and use it as the parent for this one.
+  cli_register_command(cli, c, "junk", cmd_test, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL);
+  // This one has some help text
+  cli_register_command(cli, c, "counters", cmd_test, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Show the counters that the system uses");
+
+  // Create a socket
+  s = socket(AF_INET, SOCK_STREAM, 0);
+  setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+
+  // Listen on port 12345
+  memset(&servaddr, 0, sizeof(servaddr));
+  servaddr.sin_family = AF_INET;
+  servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+  servaddr.sin_port = htons(12345);
+  bind(s, (struct sockaddr *)&servaddr, sizeof(servaddr));
+
+  // Wait for a connection
+  listen(s, 50);
+
+  while ((x = accept(s, NULL, 0))) {
+    // Pass the connection off to libcli
+    cli_loop(cli, x);
+    close(x);
+  }
+
+  // Free data structures
+  cli_done(cli);
+
+  return 0;
+}
+```
+
+This code snippet is all that's required to enable a libcli program. However it's not yet compilable because we haven't created the callback functions.
+
+A few commands have been created:
+
+* `test`
+* `simple`
+* `set`
+* `show junk`
+* `show counters`
+
+Note that `simon` isn't on this list because `callback` was `NULL` when it was registered, so the command will not be available.
+
+Also, the standard libcli commands `help`, `exit`, `logout`, `quit` and `history` are also available automatically.
+
+Make this program complete by adding the callback functions
+
+```c
+int cmd_test(struct cli_def *cli, char *command, char *argv[], int argc) {
+  cli_print(cli, "called %s with %s\r\n", __FUNCTION__, command);
+  return CLI_OK;
+}
+
+int cmd_set(struct cli_def *cli, char *command, char *argv[], int argc) {
+  if (argc < 2) {
+    cli_print(cli, "Specify a variable to set\r\n");
+    return CLI_OK;
+  }
+  cli_print(cli, "Setting %s to %s\r\n", argv[0], argv[1]);
+  return CLI_OK;
+}
+```
+
+2 callback functions are defined here, `cmd_test()` and `cmd_set()`. `cmd_test()` is called by many of the commands defined in the tutorial, although in reality you would usually use a callback for a single command.
+
+`cmd_test()` simply echos the command entered back to the client. Note that it shows the full expanded command, so you can enter "`te`" at the prompt and it will print back "`called with test`".
+
+`cmd_set()` handles the arguments given on the command line. This allows you to use a single callback to handle lots of arguments like:
+
+* `set colour green`
+* `set name David`
+* `set email "I don't have an e-mail address"`
+* etc...
+
+Compile the code
+
+```sh
+gcc libclitest.c -o libclitest -lcli
+```
+
+You can now run the program with `./libclitest` and telnet to port 12345 to see your work in action.
+
+## Function Reference
+
+### cli\_init()
+This must be called before any other cli_xxx function. It sets up the internal data structures used for command-line processing.
+
+Returns a `struct cli_def *` which must be passed to all other `cli_xxx` functions.
+
+### cli\_done(struct cli\_def \*cli)
+This is optional, but it's a good idea to call this when you are finished with libcli. This frees memory used by libcli.
+
+### cli\_register\_command(struct cli\_def \*cli, struct cli\_command *parent, char *command, int (*callback)(struct cli\_def *, char *, char **, int), int privilege, int mode, char *help)
+Add a command to the internal command tree. Returns a `struct cli_command *`, which you can pass as parent to another call to `cli_register_command()`.
+
+When the command has been entered by the user, callback is checked. If it is not `NULL`, then the callback is called with:
+
+`struct cli_def *` - the handle of the cli structure. This must be passed to all cli functions, including `cli_print()`.
+`char *` - the entire command which was entered. This is after command expansion.
+`char **` - the list of arguments entered
+`int` - the number of arguments entered
+The callback must return `CLI_OK` if the command was successful, `CLI_ERROR` if processing wasn't successful and the next matching command should be tried (if any), or `CLI_QUIT` to drop the connection (e.g. on a fatal error).
+
+If parent is `NULL`, the command is added to the top level of commands, otherwise it is a subcommand of parent.
+
+privilege should be set to either PRIVILEGE\_PRIVILEGED or PRIVILEGE\_UNPRIVILEGED. If set to PRIVILEGE\_PRIVILEGED then the user must have entered enable before running this command.
+
+`mode` should be set to `MODE_EXEC` for no configuration mode, `MODE_CONFIG` for generic configuration commands, or your own config level. The user can enter the generic configuration level by entering configure terminal, and can return to `MODE_EXEC` by entering exit or CTRL-Z. You can define commands to enter your own configuration levels, which should call the `cli_set_configmode()` function.
+
+If help is provided, it is given to the user when the use the help command or press ?.
+
+### cli\_unregister\_command(struct cli\_def \*cli, char *command)
+Remove a command command and all children. There is not provision yet for removing commands at lower than the top level.
+
+### cli\_loop(struct cli\_def \*cli, int sockfd)
+The main loop of the command-line environment. This must be called with the FD of a socket open for bi-directional communication (sockfd).
+
+### cli\_loop() handles the telnet negotiation and authentication. It returns only when the connection is finished, either by a server or client disconnect.
+Returns `CLI_OK`.
+
+### cli\_set\_auth\_callback(struct cli\_def \*cli, int (*auth\_callback)(char *, char *))
+Enables or disables callback based authentication.
+
+If `auth_callback` is not `NULL`, then authentication will be required on connection. `auth_callback` will be called with the username and password that the user enters.
+
+`auth_callback` must return a non-zero value if authentication is successful.
+
+If `auth_callback` is `NULL`, then callback based authentication will be disabled.
+
+### cli\_allow\_user(struct cli\_def \*cli, char *username, char *password)
+Enables internal authentication, and adds username/password to the list of allowed users.
+
+The internal list of users will be checked before callback based authentication is tried.
+
+### cli\_deny\_user(struct cli\_def \*cli, char *username)
+Removes username/password from the list of allowed users.
+
+If this is the last combination in the list, then internal authentication will be disabled.
+
+### cli\_set\_banner(struct cli\_def \*cli, char *banner)
+Sets the greeting that clients will be presented with when they connect. This may be a security warning for example.
+
+If this function is not called or called with a `NULL` argument, no banner will be presented.
+
+### cli\_set\_hostname(struct cli\_def \*cli, char *hostname)
+Sets the hostname to be displayed as the first part of the prompt.
+
+### cli\_regular(struct cli\_def \*cli, int(*callback)(struct cli\_def *))
+Adds a callback function which will be called every second that a user is connected to the cli. This can be used for regular processing such as debugging, time counting or implementing idle timeouts.
+
+Pass `NULL` as the callback function to disable this at runtime.
+
+If the callback function does not return `CLI_OK`, then the user will be disconnected.
+
+### cli\_file(struct cli\_def \*cli, FILE *f, int privilege, int mode)
+This reads and processes every line read from f as if it were entered at the console. The privilege level will be set to privilege and mode set to mode during the processing of the file.
+
+### cli\_print(struct cli\_def \*cli, char *format, ...)
+This function should be called for any output generated by a command callback.
+
+It takes a printf() style format string and a variable number of arguments.
+
+Be aware that any output generated by `cli_print()` will be passed through any filter currently being applied, and the output will be redirected to the `cli_print_callback()` if one has been specified.
+
+### cli\_error(struct cli\_def \*cli, char *format, ...)
+A variant of `cli_print()` which does not have filters applied.
+
+### cli\_print\_callback(struct cli\_def \*cli, void (*callback)(struct cli\_def *, char *))
+Whenever `cli_print()` or `cli_error()` is called, the output generally goes to the user. If you specify a callback using this function, then the output will be sent to that callback. The function will be called once for each line, and it will be passed a single null-terminated string, without any newline characters.
+
+Specifying `NULL` as the callback parameter will make libcli use the default `cli_print()` function.
+
+### cli\_set\_enable\_callback(struct cli\_def \*cli, void (*callback)(struct cli\_def *, char *))
+Just like `cli_set_auth_callback, this takes a pointer to a callback function to authorize privileged access. However this callback only takes a single string - the password.
+
+### cli\_allow\_enable(struct cli\_def \*cli, char *password)
+This will allow a static password to be used for the enable command. This static password will be checked before running any enable callbacks.
+
+Set this to `NULL` to not have a static enable password.
+
+### cli\_set\_configmode(struct cli\_def \*cli, int mode, char *string)
+This will set the configuration mode. Once set, commands will be restricted to only ones in the selected configuration mode, plus any set to `MODE_ANY`. The previous mode value is returned.
+
+The string passed will be used to build the prompt in the set configuration mode. e.g. if you set the string `test`, the prompt will become:
+
+```
+hostname(config-test)#
+```
+

--- a/libcli.c
+++ b/libcli.c
@@ -3000,7 +3000,7 @@ static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage
        * Otherwise if the word is 'blank', could be an argument, or matches 'enough' of an option/flag it is a candidate
        * Once we accept an argument as a candidate, we're done looking for candidates as straight arguments are required
        */
-      if ((oaptr->flags & CLI_CMD_SPOT_CHECK) && (num_candidates==0)) {
+      if ((oaptr->flags & CLI_CMD_SPOT_CHECK) && (num_candidates == 0)) {
         stage->status = (*oaptr->validator)(cli, NULL, NULL);
         if (stage->status != CLI_OK) {
           stage->error_word = stage->words[w_idx];

--- a/libcli.c
+++ b/libcli.c
@@ -2329,20 +2329,20 @@ int cli_int_enter_buildmode(struct cli_def *cli, struct cli_pipeline_stage *stag
                             NULL);
       } else {
           rc = CLI_BUILDMODE_ERROR;
-	  goto out;
+          goto out;
       }
     } else {
       if (optarg->flags & CLI_CMD_OPTION_MULTIPLE) {
         if (!cli_int_register_buildmode_command(cli, NULL, optarg->name, cli_int_buildmode_flag_multiple_cback,
                                                 optarg->privilege, cli->mode, optarg->help)) {
           rc = CLI_BUILDMODE_ERROR;
-	  goto out;
+          goto out;
         }
       } else {
         if (!cli_int_register_buildmode_command(cli, NULL, optarg->name, cli_int_buildmode_flag_cback,
                                                 optarg->privilege, cli->mode, optarg->help)) {
           rc = CLI_BUILDMODE_ERROR;
-	  goto out;
+          goto out;
         }
       }
     }
@@ -2361,7 +2361,7 @@ int cli_int_enter_buildmode(struct cli_def *cli, struct cli_pipeline_stage *stag
                       "setting to clear", cli_int_buildmode_unset_completor, cli_int_buildmode_unset_validator, NULL);
 
 out:
-  if (rc!=CLI_BUILDMODE_START) {
+  if (rc != CLI_BUILDMODE_START) {
     cli_int_free_buildmode(cli);
   }
   return rc;

--- a/libcli.c
+++ b/libcli.c
@@ -565,7 +565,7 @@ struct cli_def *cli_init() {
 
   c = cli_register_command(cli, 0, "configure", 0, PRIVILEGE_PRIVILEGED, MODE_EXEC, "Enter configuration mode");
   cli_register_command(cli, c, "terminal", cli_int_configure_terminal, PRIVILEGE_PRIVILEGED, MODE_EXEC,
-                       "Configure from the terminal");
+                       "Conlfigure from the terminal");
 
   // and now the built in filters
   c = cli_register_filter(cli, "begin", cli_range_filter_init, cli_range_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY,
@@ -2544,7 +2544,7 @@ int cli_int_buildmode_unset_completor(struct cli_def *cli, const char *name, con
 }
 
 int cli_int_buildmode_unset_validator(struct cli_def *cli, const char *name, const char *value) {
-  return CLI_OK
+  return CLI_OK;
 }
 
 void cli_set_transient_mode(struct cli_def *cli, int transient_mode) {

--- a/libcli.c
+++ b/libcli.c
@@ -3089,7 +3089,7 @@ static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage
         // need to combine remaining words if the CLI_CMD_REMAINDER_OF_LINE flag it set, then we're done processing
 	int set_value_return = 0;
 	
-/*	if (oaptr->flags & CLI_CMD_REMAINDER_OF_LINE) {
+	if (oaptr->flags & CLI_CMD_REMAINDER_OF_LINE) {
 	  char *combined=NULL;
 	  combined = join_words(stage->num_words-w_idx, stage->words + w_idx);
 	  set_value_return = cli_int_add_optarg_value(cli, oaptr->name, combined, 0);
@@ -3097,7 +3097,7 @@ static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage
 	} else {
 	  set_value_return = cli_int_add_optarg_value(cli, oaptr->name, value, oaptr->flags&CLI_CMD_OPTION_MULTIPLE);
 	}
-*/	  set_value_return = cli_int_add_optarg_value(cli, oaptr->name, value, oaptr->flags&CLI_CMD_OPTION_MULTIPLE);
+
 	if (set_value_return != CLI_OK) {
           cli_error(cli,"%sProblem setting value for command argument %s", lastchar=='\0'?"" : "\n", stage->words[w_idx]);
           cli_reprompt(cli);

--- a/libcli.c
+++ b/libcli.c
@@ -2307,9 +2307,10 @@ int cli_int_enter_buildmode(struct cli_def *cli, struct cli_pipeline_stage *stag
 
   // build new *limited* list of commands from this commands optargs
   for (optarg = stage->command->optargs; optarg; optarg = optarg->next) {
-    // don't allow anything that could redefine our mode or buildmode mode, or redefine exit/cancel
-    if (!strcmp(optarg->name, "cancel") || (!strcmp(optarg->name, "exit"))) {
-      cli_error(cli, "Unable to build buildmode mode from optarg named %s", optarg->name);
+    // don't allow anything that could redefine our mode or buildmode mode, or redefine exit/cancel/show/unset
+    if (!strcmp(optarg->name, "cancel") || (!strcmp(optarg->name, "exit")) ||
+        !strcmp(optarg->name, "show") || (!strcmp(optarg->name, "unset"))) {
+      cli_error(cli, "Default buildmode command conflicts with optarg named %s", optarg->name);
       rc = CLI_BUILDMODE_ERROR;
       goto out;
     }
@@ -2343,7 +2344,7 @@ int cli_int_enter_buildmode(struct cli_def *cli, struct cli_pipeline_stage *stag
     }
   }
   cli->buildmode->cname = strdup(cli_command_name(cli, stage->command));
-  // and lastly two 'always there' commands to cancel current mode and to execute the command
+  // and lastly four 'always there' commands to cancel current mode and to execute the command, show settings, and unset 
   cli_int_register_buildmode_command(cli, NULL, "cancel", cli_int_buildmode_cancel_cback, PRIVILEGE_UNPRIVILEGED,
                                      cli->mode, "Cancel command");
   cli_int_register_buildmode_command(cli, NULL, "exit", cli_int_buildmode_exit_cback, PRIVILEGE_UNPRIVILEGED, cli->mode,

--- a/libcli.c
+++ b/libcli.c
@@ -3000,7 +3000,14 @@ static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage
        * Otherwise if the word is 'blank', could be an argument, or matches 'enough' of an option/flag it is a candidate
        * Once we accept an argument as a candidate, we're done looking for candidates as straight arguments are required
        */
-      if (stage->words[w_idx] && (oaptr->flags & (CLI_CMD_OPTIONAL_FLAG | CLI_CMD_OPTIONAL_ARGUMENT)) &&
+      if ((oaptr->flags & CLI_CMD_SPOT_CHECK) && (num_candidates==0)) {
+        stage->status = (*oaptr->validator)(cli, NULL, NULL);
+        if (stage->status != CLI_OK) {
+          stage->error_word = stage->words[w_idx];
+          cli_reprompt(cli);
+          return;
+        }
+      } else if (stage->words[w_idx] && (oaptr->flags & (CLI_CMD_OPTIONAL_FLAG | CLI_CMD_OPTIONAL_ARGUMENT)) &&
           !strcmp(oaptr->name, stage->words[w_idx])) {
         candidates[0] = oaptr;
         num_candidates = 1;
@@ -3035,7 +3042,7 @@ static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage
     /*
      * So now we could have one or more candidates.  We need to call get help/completions *only* if this is the
      * 'last-word'
-     * Remember that last word for optinal arguments is last or next to last....
+     * Remember that last word for optional arguments is last or next to last....
      */
     if (lastchar != '\0') {
       int called_comphelp = 0;

--- a/libcli.c
+++ b/libcli.c
@@ -447,9 +447,8 @@ static void cli_free_command(struct cli_def *cli, struct cli_command *cmd) {
    * Ok, update the pointers of anyone who pointed to us.
    * We have 3 pointers to worry about - parent, previous, and next.
    * We don't have to worry about children since they've been cleared above.
-   * If both parent *and* previous being null this means that
-   *   cli->command points to us, so we need to only update
-   *   cli->command to point to next.  
+   * If both cli->command points to us we need to update
+   *   cli->command to point to whatever command is 'next'.  
    * Otherwise ensure that any item before/behind us points
    *   around us.  
    *
@@ -459,7 +458,7 @@ static void cli_free_command(struct cli_def *cli, struct cli_command *cmd) {
    * The above freeing of children prevents this in the first place.    
    */
    
-  if (!cmd->parent && !cmd->previous) {
+  if (cmd == cli->commands ) {
     cli->commands = cmd->next;
     if (cmd->next) {
       cmd->next->parent = NULL;

--- a/libcli.c
+++ b/libcli.c
@@ -2172,9 +2172,8 @@ int cli_unregister_optarg(struct cli_command *cmd, const char *name) {
   struct cli_optarg *lastptr;
   int retval = CLI_ERROR;
   // iterate looking for this option name, stopping at end or if name matches
-  for (lastptr = NULL, ptr = cmd->optargs; ptr && strcmp(ptr->name, name); lastptr = ptr, ptr = ptr->next) {
+  for (lastptr = NULL, ptr = cmd->optargs; ptr && strcmp(ptr->name, name); lastptr = ptr, ptr = ptr->next)
     ;
-  }
 
   // if ptr, then we found the optarg to delete
   if (ptr) {

--- a/libcli.c
+++ b/libcli.c
@@ -37,13 +37,9 @@
  * Stupid windows has multiple namespaces for filedescriptors, with different
  * read/write functions required for each ..
  */
-int read(int fd, void *buf, unsigned int count) {
-  return recv(fd, buf, count, 0);
-}
+int read(int fd, void *buf, unsigned int count) { return recv(fd, buf, count, 0); }
 
-int write(int fd, const void *buf, unsigned int count) {
-  return send(fd, buf, count, 0);
-}
+int write(int fd, const void *buf, unsigned int count) { return send(fd, buf, count, 0); }
 
 int vasprintf(char **strp, const char *fmt, va_list args) {
   int size;
@@ -105,7 +101,13 @@ int regex_dummy() {
 #define REG_ICASE 0
 #endif
 
-enum cli_states { STATE_LOGIN, STATE_PASSWORD, STATE_NORMAL, STATE_ENABLE_PASSWORD, STATE_ENABLE };
+enum cli_states {
+  STATE_LOGIN,
+  STATE_PASSWORD,
+  STATE_NORMAL,
+  STATE_ENABLE_PASSWORD,
+  STATE_ENABLE
+};
 
 struct unp {
   char *username;
@@ -135,34 +137,35 @@ static int cli_count_filter_init(struct cli_def *cli, int argc, char **argv, str
 static int cli_match_filter(struct cli_def *cli, const char *string, void *data);
 static int cli_range_filter(struct cli_def *cli, const char *string, void *data);
 static int cli_count_filter(struct cli_def *cli, const char *string, void *data);
-static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage *stage, struct cli_command *cmd, char lastchar, struct cli_comphelp *comphelp);
+static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage *stage, struct cli_command *cmd,
+                                  char lastchar, struct cli_comphelp *comphelp);
 static int cli_int_enter_buildmode(struct cli_def *cli, struct cli_pipeline_stage *stage, char *mode_text);
-static char * cli_int_buildmode_extend_cmdline(char *, char *word); 
+static char *cli_int_buildmode_extend_cmdline(char *, char *word);
 static void cli_int_free_buildmode(struct cli_def *cli);
 static int cli_int_add_optarg_value(struct cli_def *cli, const char *name, const char *value, int allow_multiple);
 static void cli_free_command(struct cli_command *cmd);
-static int cli_int_unregister_buildmode_command(struct cli_def *cli, const char *command) __attribute__((unused)) ;
-static struct cli_command *cli_int_register_buildmode_command(struct cli_def *cli, struct cli_command *parent, const char *command,
-                                         int (*callback)(struct cli_def *cli, const char *, char **, int),
-                                         int privilege, int mode, const char *help) ;
-static int cli_int_buildmode_cmd_cback(struct cli_def *cli, const char *command, char *argv[], int argc) ;
-static int cli_int_buildmode_flag_cback(struct cli_def *cli, const char *command, char *argv[], int argc) ;
-static int cli_int_buildmode_flag_multiple_cback(struct cli_def *cli, const char *command, char *argv[], int argc) ;
-static int cli_int_buildmode_cancel_cback(struct cli_def *cli, const char *command, char *argv[], int argc) ;
-static int cli_int_buildmode_exit_cback(struct cli_def *cli, const char *command, char *argv[], int argc) ;
-static int cli_int_buildmode_show_cback(struct cli_def *cli, const char *command, char *argv[], int argc) ;
-static int cli_int_buildmode_unset_cback(struct cli_def *cli, const char *command, char *argv[], int argc) ;
-static int cli_int_buildmode_unset_completor(struct cli_def *cli, const char *name, const char *word, struct cli_comphelp *comphelp) ;
-static int cli_int_buildmode_unset_validator(struct cli_def *cli, const char *name, const char *value) ;
+static int cli_int_unregister_buildmode_command(struct cli_def *cli, const char *command) __attribute__((unused));
+static struct cli_command *cli_int_register_buildmode_command(
+    struct cli_def *cli, struct cli_command *parent, const char *command,
+    int (*callback)(struct cli_def *cli, const char *, char **, int), int privilege, int mode, const char *help);
+static int cli_int_buildmode_cmd_cback(struct cli_def *cli, const char *command, char *argv[], int argc);
+static int cli_int_buildmode_flag_cback(struct cli_def *cli, const char *command, char *argv[], int argc);
+static int cli_int_buildmode_flag_multiple_cback(struct cli_def *cli, const char *command, char *argv[], int argc);
+static int cli_int_buildmode_cancel_cback(struct cli_def *cli, const char *command, char *argv[], int argc);
+static int cli_int_buildmode_exit_cback(struct cli_def *cli, const char *command, char *argv[], int argc);
+static int cli_int_buildmode_show_cback(struct cli_def *cli, const char *command, char *argv[], int argc);
+static int cli_int_buildmode_unset_cback(struct cli_def *cli, const char *command, char *argv[], int argc);
+static int cli_int_buildmode_unset_completor(struct cli_def *cli, const char *name, const char *word,
+                                             struct cli_comphelp *comphelp);
+static int cli_int_buildmode_unset_validator(struct cli_def *cli, const char *name, const char *value);
 static int cli_int_execute_buildmode(struct cli_def *cli);
-static void cli_int_free_found_optargs(struct cli_optarg_pair **optarg_pair) ;
-//static void cli_int_unset_optarg_value(struct cli_def *cli, const char *name ) ;
+static void cli_int_free_found_optargs(struct cli_optarg_pair **optarg_pair);
+// static void cli_int_unset_optarg_value(struct cli_def *cli, const char *name ) ;
 static struct cli_pipeline *cli_int_generate_pipeline(struct cli_def *cli, const char *command);
-static int cli_int_validate_pipeline(struct cli_def *cli, struct cli_pipeline *pipeline) ;
-static int cli_int_execute_pipeline (struct cli_def *cli, struct cli_pipeline *pipeline);
+static int cli_int_validate_pipeline(struct cli_def *cli, struct cli_pipeline *pipeline);
+static int cli_int_execute_pipeline(struct cli_def *cli, struct cli_pipeline *pipeline);
 inline void cli_int_show_pipeline(struct cli_def *cli, struct cli_pipeline *pipeline);
 static struct cli_pipeline *cli_int_free_pipeline(struct cli_pipeline *pipeline);
-
 
 static ssize_t _write(int fd, const void *buf, size_t count) {
   size_t written = 0;
@@ -543,18 +546,25 @@ struct cli_def *cli_init() {
   cli_register_command(cli, c, "terminal", cli_int_configure_terminal, PRIVILEGE_PRIVILEGED, MODE_EXEC,
                        "Configure from the terminal");
 
-
   // and now the built in filters
-  c = cli_register_filter(cli, "begin", cli_begin_filter_init, cli_range_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Begin with lines that match");
-  cli_register_optarg(c, "begin_at", CLI_CMD_ARGUMENT|CLI_CMD_REMAINDER_OF_LINE, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Begin with lines that match", NULL, NULL, NULL);
+  c = cli_register_filter(cli, "begin", cli_begin_filter_init, cli_range_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY,
+                          "Begin with lines that match");
+  cli_register_optarg(c, "begin_at", CLI_CMD_ARGUMENT | CLI_CMD_REMAINDER_OF_LINE, PRIVILEGE_UNPRIVILEGED, MODE_ANY,
+                      "Begin with lines that match", NULL, NULL, NULL);
 
-  c = cli_register_filter(cli, "between", cli_range_filter_init, cli_range_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Between lines that match");
+  c = cli_register_filter(cli, "between", cli_range_filter_init, cli_range_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY,
+                          "Between lines that match");
 
-  c = cli_register_filter(cli, "count", cli_count_filter_init, cli_count_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Count of lines");
-  c = cli_register_filter(cli, "exclude", cli_match_filter_init, cli_match_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Exclude lines that match");
-  c = cli_register_filter(cli, "include", cli_match_filter_init, cli_match_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Include lines that match");
-  c = cli_register_filter(cli, "grep", cli_match_filter_init, cli_match_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Include lines that match regex (options: -v, -i, -e)");
-  c = cli_register_filter(cli, "egrep", cli_match_filter_init, cli_match_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Include lines that match extended regex");
+  c = cli_register_filter(cli, "count", cli_count_filter_init, cli_count_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY,
+                          "Count of lines");
+  c = cli_register_filter(cli, "exclude", cli_match_filter_init, cli_match_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY,
+                          "Exclude lines that match");
+  c = cli_register_filter(cli, "include", cli_match_filter_init, cli_match_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY,
+                          "Include lines that match");
+  c = cli_register_filter(cli, "grep", cli_match_filter_init, cli_match_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY,
+                          "Include lines that match regex (options: -v, -i, -e)");
+  c = cli_register_filter(cli, "egrep", cli_match_filter_init, cli_match_filter, PRIVILEGE_UNPRIVILEGED, MODE_ANY,
+                          "Include lines that match extended regex");
 
   cli->privilege = cli->mode = -1;
   cli_set_privilege(cli, PRIVILEGE_UNPRIVILEGED);
@@ -608,7 +618,7 @@ int cli_done(struct cli_def *cli) {
   cli_unregister_all(cli, cli->commands);
   cli_unregister_all(cli, cli->filter_commands);
 
-  if ( cli->buildmode) cli_int_free_buildmode(cli);
+  if (cli->buildmode) cli_int_free_buildmode(cli);
   free_z(cli->commandname);
   free_z(cli->modestring);
   free_z(cli->banner);
@@ -713,18 +723,16 @@ static char *join_words(int argc, char **argv) {
   return p;
 }
 
-
 int cli_run_command(struct cli_def *cli, const char *command) {
-  int rc=CLI_ERROR;
-  struct cli_pipeline *pipeline ;  
+  int rc = CLI_ERROR;
+  struct cli_pipeline *pipeline;
 
-  // split command into pipeline stages, 
+  // split command into pipeline stages,
 
-  pipeline=cli_int_generate_pipeline(cli, command);
+  pipeline = cli_int_generate_pipeline(cli, command);
 
   // cli_int_validate_pipeline will deal with buildmode command setup, and return CLI_BUILDMODE_COMMAND_START if found.
-  if (pipeline) rc=cli_int_validate_pipeline(cli, pipeline);
-    
+  if (pipeline) rc = cli_int_validate_pipeline(cli, pipeline);
 
   if (rc == CLI_OK) {
     rc = cli_int_execute_pipeline(cli, pipeline);
@@ -733,91 +741,89 @@ int cli_run_command(struct cli_def *cli, const char *command) {
   return rc;
 }
 
-
-
 void cli_get_completions(struct cli_def *cli, const char *command, char lastchar, struct cli_comphelp *comphelp) {
-  struct cli_command *c=NULL;
-  struct cli_command *n=NULL;
-  struct cli_command *first_command=NULL;
+  struct cli_command *c = NULL;
+  struct cli_command *n = NULL;
+  struct cli_command *first_command = NULL;
 
   int i;
-  struct cli_pipeline *pipeline=NULL ;
+  struct cli_pipeline *pipeline = NULL;
   struct cli_pipeline_stage *stage;
-  
-  if (!(pipeline=cli_int_generate_pipeline(cli, command))) goto out;
 
-  stage=&pipeline->stage[pipeline->num_stages-1];
-  
+  if (!(pipeline = cli_int_generate_pipeline(cli, command))) goto out;
+
+  stage = &pipeline->stage[pipeline->num_stages - 1];
+
   // check to see if either *no* input, or if the lastchar is a tab.
-  if ((!stage->words[0] || (command[strlen(command) - 1] == ' ')) && (stage->words[stage->num_words-1])) stage->num_words++;
+  if ((!stage->words[0] || (command[strlen(command) - 1] == ' ')) && (stage->words[stage->num_words - 1]))
+    stage->num_words++;
 
   if (cli->buildmode && cli->buildmode->commands) {
-    first_command=cli->buildmode->commands;
-  } else if (pipeline->num_stages==1) {
-    first_command=cli->commands;
+    first_command = cli->buildmode->commands;
+  } else if (pipeline->num_stages == 1) {
+    first_command = cli->commands;
   } else {
-    first_command=cli->filter_commands;
+    first_command = cli->filter_commands;
   }
-  
-  for (c = first_command, i = 0; c && i < stage->num_words ; c = n) {
-    char *strptr=NULL;
+
+  for (c = first_command, i = 0; c && i < stage->num_words; c = n) {
+    char *strptr = NULL;
     n = c->next;
-    
+
     if (cli->privilege < c->privilege) continue;
 
-    if (c->mode != cli->mode && c->mode != MODE_ANY ) continue;
+    if (c->mode != cli->mode && c->mode != MODE_ANY) continue;
 
     if (stage->words[i] && strncasecmp(c->command, stage->words[i], strlen(stage->words[i]))) continue;
 
     // special case for 'buildmode' - skip if the argument for this command was seen, unless MULTIPLE flag is set
     if (cli->buildmode) {
       struct cli_optarg *optarg;
-      for (optarg = cli->buildmode->c->optargs; optarg; optarg=optarg->next) {
+      for (optarg = cli->buildmode->c->optargs; optarg; optarg = optarg->next) {
         if (!strcmp(optarg->name, c->command)) break;
       }
-      if (optarg && cli_find_optarg_value(cli, optarg->name, NULL) && !(optarg->flags & (CLI_CMD_OPTION_MULTIPLE))) continue;
+      if (optarg && cli_find_optarg_value(cli, optarg->name, NULL) && !(optarg->flags & (CLI_CMD_OPTION_MULTIPLE)))
+        continue;
     }
-    if (i < stage->num_words-1) {
+    if (i < stage->num_words - 1) {
       if (stage->words[i] && (strlen(stage->words[i]) < c->unique_len) && strcmp(stage->words[i], c->command)) continue;
 
       n = c->children;
-      
-      // if we have no more children, we've matched the *command* - remember this 
+
+      // if we have no more children, we've matched the *command* - remember this
       if (!c->children) {
         break;
       }
-      
+
       i++;
       continue;
     }
-    
+
     if ((lastchar == '?')) {
-      if (asprintf(&strptr,"  %-20s %s", c->command, (c->help)?c->help : "") != -1 ) {
+      if (asprintf(&strptr, "  %-20s %s", c->command, (c->help) ? c->help : "") != -1) {
         cli_add_comphelp_entry(comphelp, strptr);
         free_z(strptr);
       }
     } else {
-        cli_add_comphelp_entry(comphelp, c->command);
+      cli_add_comphelp_entry(comphelp, c->command);
     }
-    
   }
 
 out:
   if (c) {
     // advance past first word of stage
-    i++; 
-    stage->first_unmatched=i;
-    if (c->optargs ) {
-    
+    i++;
+    stage->first_unmatched = i;
+    if (c->optargs) {
+
       cli_int_parse_optargs(cli, stage, c, lastchar, comphelp);
-    } else if (lastchar == '?')  {
+    } else if (lastchar == '?') {
       // special case for getting help with no defined optargs....
       comphelp->num_entries = -1;
     }
   }
 
-  pipeline=cli_int_free_pipeline(pipeline);
-
+  pipeline = cli_int_free_pipeline(pipeline);
 }
 
 static void cli_clear_line(int sockfd, char *cmd, int l, int cursor) {
@@ -868,8 +874,7 @@ static int pass_matches(const char *pass, const char *try) {
   /*
    * TODO - find a small crypt(3) function for use on windows
    */
-  if (des || !strncmp(pass, MD5_PREFIX, sizeof(MD5_PREFIX) - 1)) try
-      = crypt(try, pass);
+  if (des || !strncmp(pass, MD5_PREFIX, sizeof(MD5_PREFIX) - 1)) try = crypt(try, pass);
 #endif
 
   return !strcmp(pass, try);
@@ -885,14 +890,13 @@ static int show_prompt(struct cli_def *cli, int sockfd) {
   if (cli->modestring) len += write(sockfd, cli->modestring, strlen(cli->modestring));
   if (cli->buildmode) {
     len += write(sockfd, "[", 1);
-    len += write(sockfd, cli->buildmode->cname, strlen(cli->buildmode->cname)); 
+    len += write(sockfd, cli->buildmode->cname, strlen(cli->buildmode->cname));
     len += write(sockfd, "...", 3);
     if (cli->buildmode->mode_text) len += write(sockfd, cli->buildmode->mode_text, strlen(cli->buildmode->mode_text));
-    len+= write(sockfd, "]", 1);
+    len += write(sockfd, "]", 1);
   }
   return len + write(sockfd, cli->promptchar, strlen(cli->promptchar));
 }
-
 
 int cli_loop(struct cli_def *cli, int sockfd) {
   int n, l, oldl = 0, is_telnet_option = 0, skip = 0, esc = 0, cursor = 0;
@@ -966,13 +970,13 @@ int cli_loop(struct cli_def *cli, int sockfd) {
     while (1) {
       int sr;
       fd_set r;
-      
+
       /*
        * ensure our transient mode is reset to the starting mode on *each* loop traversal
        * transient mode is valid only while a command is being evaluated/executed
        */
       cli->transient_mode = cli->mode;
-      
+
       if (cli->showprompt) {
         if (cli->state != STATE_PASSWORD && cli->state != STATE_ENABLE_PASSWORD) _write(sockfd, "\r\n", 2);
 
@@ -1265,14 +1269,14 @@ int cli_loop(struct cli_def *cli, int sockfd) {
 
         if (cursor != l) continue;
 
-        cli_get_completions(cli, cmd, c, &comphelp); 
+        cli_get_completions(cli, cmd, c, &comphelp);
         if (comphelp.num_entries == 0) {
           _write(sockfd, "\a", 1);
         } else if (lastchar == CTRL('I')) {
           // double tab
           int i;
           for (i = 0; i < comphelp.num_entries; i++) {
-            if (i % 4 == 0      )
+            if (i % 4 == 0)
               _write(sockfd, "\r\n", 2);
             else
               _write(sockfd, " ", 1);
@@ -1282,9 +1286,9 @@ int cli_loop(struct cli_def *cli, int sockfd) {
           cli->showprompt = 1;
         } else if (comphelp.num_entries == 1) {
           // Single completion - show *unless* the optional/required 'prefix' is present
-          if ((comphelp.entries[0][0]!='[') && (comphelp.entries[0][0]!='<')) {
+          if ((comphelp.entries[0][0] != '[') && (comphelp.entries[0][0] != '<')) {
             for (; l > 0; l--, cursor--) {
-              if (cmd[l - 1] == ' ' || cmd[l - 1] == '|' || (comphelp.comma_separated && cmd[l-1]==',')) break;
+              if (cmd[l - 1] == ' ' || cmd[l - 1] == '|' || (comphelp.comma_separated && cmd[l - 1] == ',')) break;
               _write(sockfd, "\b", 1);
             }
             strcpy((cmd + l), comphelp.entries[0]);
@@ -1299,55 +1303,59 @@ int cli_loop(struct cli_def *cli, int sockfd) {
             // Yes, we had a match, but it wasn't required - remember the tab in case the user double tabs....
             lastchar = CTRL('I');
           }
-        } else if (comphelp.num_entries>1) {
+        } else if (comphelp.num_entries > 1) {
           /* More than one completion
            * Show as many characters as we can until the completions start to differ
            */
           lastchar = c;
-          int i,j,k=0;
+          int i, j, k = 0;
           char *tptr = comphelp.entries[0];
-          
+
           /* quickly try to see where our entries differ
            * corner cases
            * - if all entries are optional, don't show
-           *   *any* options unless user has provided a letter. 
-           * - if any entry starts with '<' then don't fill in 
+           *   *any* options unless user has provided a letter.
+           * - if any entry starts with '<' then don't fill in
            *   anything.
            */
-          
+
           // skip a leading '['
           k = strlen(tptr);
-          if (*tptr == '[') tptr++;
-          else if (*tptr == '<') k=0;
+          if (*tptr == '[')
+            tptr++;
+          else if (*tptr == '<')
+            k = 0;
 
-          for (i = 1; k!=0 && i < comphelp.num_entries; i++) {
-            char *wptr=comphelp.entries[i];
-            
-            if (*wptr=='[') wptr++;
-            else if (*wptr=='<') k=0;
-            
-            for (j=0; (j<k) && (j<(int)strlen(wptr)) ; j++) {
-              if (strncasecmp(tptr+j, wptr+j,1)) break;
+          for (i = 1; k != 0 && i < comphelp.num_entries; i++) {
+            char *wptr = comphelp.entries[i];
+
+            if (*wptr == '[')
+              wptr++;
+            else if (*wptr == '<')
+              k = 0;
+
+            for (j = 0; (j < k) && (j < (int)strlen(wptr)); j++) {
+              if (strncasecmp(tptr + j, wptr + j, 1)) break;
             }
-            k=j;
+            k = j;
           }
-          
+
           /*
-           * ok, try to show minimum match string if we have a 
-           * non-zero k and the first letter of the last word 
+           * ok, try to show minimum match string if we have a
+           * non-zero k and the first letter of the last word
            * is not '['
            */
-          if (k && (comphelp.entries[comphelp.num_entries-1][0] != '[')) {
+          if (k && (comphelp.entries[comphelp.num_entries - 1][0] != '[')) {
             for (; l > 0; l--, cursor--) {
-              if (cmd[l - 1] == ' ' || cmd[l - 1] == '|' || (comphelp.comma_separated && cmd[l-1]==',')) break;
+              if (cmd[l - 1] == ' ' || cmd[l - 1] == '|' || (comphelp.comma_separated && cmd[l - 1] == ',')) break;
               _write(sockfd, "\b", 1);
             }
-            strncpy((cmd + l), tptr,k);
+            strncpy((cmd + l), tptr, k);
             l += k;
             cursor = l;
             _write(sockfd, tptr, k);
 
-          } else { 
+          } else {
             _write(sockfd, "\a", 1);
           }
         }
@@ -1356,10 +1364,10 @@ int cli_loop(struct cli_def *cli, int sockfd) {
       }
 
       /* '?' at end of line - generate applicable 'help' messages */
-      if ((c == '?') && (cursor == l) ) {
+      if ((c == '?') && (cursor == l)) {
         struct cli_comphelp comphelp = {0};
         int i;
-        int show_cr=1;
+        int show_cr = 1;
 
         if (cli->state == STATE_LOGIN || cli->state == STATE_PASSWORD || cli->state == STATE_ENABLE_PASSWORD) continue;
 
@@ -1368,20 +1376,19 @@ int cli_loop(struct cli_def *cli, int sockfd) {
         cli_get_completions(cli, cmd, c, &comphelp);
         if (comphelp.num_entries == 0) {
           _write(sockfd, "\a", 1);
-        }
-        else if (comphelp.num_entries > 0) {
+        } else if (comphelp.num_entries > 0) {
           cli->showprompt = 1;
           _write(sockfd, "\r\n", 2);
-          for (i=0;i<(int)comphelp.num_entries;i++) {
-            if (comphelp.entries[i][2]!='[') show_cr=0;
-            cli_error(cli, "%s",comphelp.entries[i]);
+          for (i = 0; i < (int)comphelp.num_entries; i++) {
+            if (comphelp.entries[i][2] != '[') show_cr = 0;
+            cli_error(cli, "%s", comphelp.entries[i]);
           }
-          if (show_cr) cli_error(cli,"  <cr>");
+          if (show_cr) cli_error(cli, "  <cr>");
         }
-        
+
         cli_free_comphelp(&comphelp);
-        
-        if ( comphelp.num_entries>=0) continue;
+
+        if (comphelp.num_entries >= 0) continue;
       }
 
       /* history */
@@ -1595,16 +1602,16 @@ int cli_loop(struct cli_def *cli, int sockfd) {
       if (l == 0) continue;
       if (cmd[l - 1] != '?' && strcasecmp(cmd, "history") != 0) cli_add_history(cli, cmd);
 
-      rc=cli_run_command(cli, cmd);
+      rc = cli_run_command(cli, cmd);
       switch (rc) {
         case CLI_BUILDMODE_COMMAND_ERROR:
           // unable to enter buildmode successfully
-          cli_print(cli, "Failure entering build mode for '%s'" , cli->buildmode->cname);
+          cli_print(cli, "Failure entering build mode for '%s'", cli->buildmode->cname);
           cli_int_free_buildmode(cli);
           continue;
         case CLI_BUILDMODE_COMMAND_CANCEL:
           // called if user enters 'cancel'
-          cli_print(cli, "Canceling build mode for '%s'" , cli->buildmode->cname);
+          cli_print(cli, "Canceling build mode for '%s'", cli->buildmode->cname);
           cli_int_free_buildmode(cli);
           break;
         case CLI_BUILDMODE_COMMAND_EXIT:
@@ -1619,9 +1626,9 @@ int cli_loop(struct cli_def *cli, int sockfd) {
         default:
           break;
       }
-      
-      // Process is done if we get a CLI_QUIT, 
-      if (rc==CLI_QUIT) break;
+
+      // Process is done if we get a CLI_QUIT,
+      if (rc == CLI_QUIT) break;
     }
 
     // Update the last_action time now as the last command run could take a
@@ -1724,9 +1731,7 @@ void cli_bufprint(struct cli_def *cli, const char *format, ...) {
   va_end(ap);
 }
 
-void cli_vabufprint(struct cli_def *cli, const char *format, va_list ap) {
-  _print(cli, PRINT_BUFFERED, format, ap);
-}
+void cli_vabufprint(struct cli_def *cli, const char *format, va_list ap) { _print(cli, PRINT_BUFFERED, format, ap); }
 
 void cli_print(struct cli_def *cli, const char *format, ...) {
   va_list ap;
@@ -1767,7 +1772,7 @@ int cli_match_filter_init(struct cli_def *cli, int argc, char **argv, struct cli
   filt->filter = cli_match_filter;
   filt->data = state = calloc(sizeof(struct cli_match_filter_state), 1);
   if (!state) return CLI_ERROR;
-  
+
   if (argv[0][0] == 'i' || (argv[0][0] == 'e' && argv[0][1] == 'x'))  // include/exclude
   {
     if (argv[0][0] == 'e') state->flags = MATCH_INVERT;
@@ -1992,26 +1997,19 @@ void cli_set_idle_timeout_callback(struct cli_def *cli, unsigned int seconds, in
   cli->idle_timeout_callback = callback;
 }
 
-void cli_telnet_protocol(struct cli_def *cli, int telnet_protocol) {
-  cli->telnet_protocol = !!telnet_protocol;
-}
+void cli_telnet_protocol(struct cli_def *cli, int telnet_protocol) { cli->telnet_protocol = !!telnet_protocol; }
 
-void cli_set_context(struct cli_def *cli, void *context) {
-  cli->user_context = context;
-}
+void cli_set_context(struct cli_def *cli, void *context) { cli->user_context = context; }
 
-void *cli_get_context(struct cli_def *cli) {
-  return cli->user_context;
-}
+void *cli_get_context(struct cli_def *cli) { return cli->user_context; }
 
-
-/* cli_register_filter/cli_unregister_filter are limited coies of cli_register_command/cli_unregister_command.  
+/* cli_register_filter/cli_unregister_filter are limited coies of cli_register_command/cli_unregister_command.
  * Filters do not have a hierarchy, so they are all siblings of each other so we only need the 'next' field.
  */
 struct cli_command *cli_register_filter(struct cli_def *cli, const char *command,
-                                         int(*init) (struct cli_def *cli, int, char **, struct cli_filter *),
-                                         int(*filter)(struct cli_def *, const char *, void *),
-                                         int privilege, int mode, const char *help) {
+                                        int (*init)(struct cli_def *cli, int, char **, struct cli_filter *),
+                                        int (*filter)(struct cli_def *, const char *, void *), int privilege, int mode,
+                                        const char *help) {
   struct cli_command *c, *p;
 
   if (!command) return NULL;
@@ -2034,7 +2032,7 @@ struct cli_command *cli_register_filter(struct cli_def *cli, const char *command
   }
 
   if (!cli->filter_commands) {
-      cli->filter_commands = c;
+    cli->filter_commands = c;
   } else {
     for (p = cli->filter_commands; p && p->next; p = p->next)
       ;
@@ -2042,7 +2040,6 @@ struct cli_command *cli_register_filter(struct cli_def *cli, const char *command
   }
   return c;
 }
-
 
 int cli_unregister_filter(struct cli_def *cli, const char *command) {
   struct cli_command *c, *p = NULL;
@@ -2064,30 +2061,29 @@ int cli_unregister_filter(struct cli_def *cli, const char *command) {
   return CLI_OK;
 }
 
-
 void cli_int_free_found_optargs(struct cli_optarg_pair **optarg_pair) {
   struct cli_optarg_pair *c;
 
-  if (!optarg_pair || !*optarg_pair) return ;
-  
-  for (c=*optarg_pair;c;) {
-    *optarg_pair=c->next;
+  if (!optarg_pair || !*optarg_pair) return;
+
+  for (c = *optarg_pair; c;) {
+    *optarg_pair = c->next;
     free_z(c->name);
     free_z(c->value);
     free_z(c);
-    c=*optarg_pair;
+    c = *optarg_pair;
   }
 }
 
 char *cli_find_optarg_value(struct cli_def *cli, char *name, char *find_after) {
-  char *value=NULL;
+  char *value = NULL;
   struct cli_optarg_pair *optarg_pair;
   if (!name || !cli->found_optargs) return NULL;
-  
-  for (optarg_pair = cli->found_optargs; optarg_pair && !value ; optarg_pair=optarg_pair->next) {
-    if (strcmp(optarg_pair->name, name)==0) {
-      if (find_after && (find_after==optarg_pair->value)) {
-        find_after=NULL;
+
+  for (optarg_pair = cli->found_optargs; optarg_pair && !value; optarg_pair = optarg_pair->next) {
+    if (strcmp(optarg_pair->name, name) == 0) {
+      if (find_after && (find_after == optarg_pair->value)) {
+        find_after = NULL;
         continue;
       }
       value = optarg_pair->value;
@@ -2100,14 +2096,14 @@ static void cli_optarg_build_shortest(struct cli_optarg *optarg) {
   struct cli_optarg *c, *p;
   char *cp, *pp;
   unsigned int len;
-  
+
   for (c = optarg; c; c = c->next) {
     c->unique_len = 1;
-    for (p=optarg; p; p=p->next) {
-      if (c==p) continue;
+    for (p = optarg; p; p = p->next) {
+      if (c == p) continue;
       cp = c->name;
       pp = p->name;
-      len=1;
+      len = 1;
       while (*cp && *pp && *cp++ == *pp++) len++;
       if (len > c->unique_len) c->unique_len = len;
     }
@@ -2117,26 +2113,25 @@ static void cli_optarg_build_shortest(struct cli_optarg *optarg) {
 void cli_free_optarg(struct cli_optarg *optarg) {
   free_z(optarg->help);
   free_z(optarg->name);
-  free_z(optarg);  
+  free_z(optarg);
 }
 
-
 int cli_register_optarg(struct cli_command *cmd, const char *name, int flags, int privilege, int mode, const char *help,
-                        int (*get_completions)(struct cli_def *cli, const char *, const char *, struct cli_comphelp * ),
+                        int (*get_completions)(struct cli_def *cli, const char *, const char *, struct cli_comphelp *),
                         int (*validator)(struct cli_def *cli, const char *, const char *),
                         int (*transient_mode)(struct cli_def *cli, const char *, const char *)) {
   struct cli_optarg *optarg;
-  struct cli_optarg *lastopt=NULL;
-  struct cli_optarg *ptr=NULL;
+  struct cli_optarg *lastopt = NULL;
+  struct cli_optarg *ptr = NULL;
   int retval = CLI_ERROR;
-   
+
   // name must not already exist with this priv/mode
-  for (ptr=cmd->optargs,lastopt=NULL; ptr ;lastopt=ptr, ptr=ptr->next) {
+  for (ptr = cmd->optargs, lastopt = NULL; ptr; lastopt = ptr, ptr = ptr->next) {
     if (!(strcmp(name, ptr->name)) && (ptr->mode == mode) && (ptr->privilege == privilege)) {
       return CLI_ERROR;
     }
   }
-  if (!(optarg = calloc(sizeof(struct cli_optarg),1))) goto CLEANUP;
+  if (!(optarg = calloc(sizeof(struct cli_optarg), 1))) goto CLEANUP;
   if (!(optarg->name = strdup(name))) goto CLEANUP;
   if (help && !(optarg->help = strdup(help))) goto CLEANUP;
 
@@ -2147,11 +2142,13 @@ int cli_register_optarg(struct cli_command *cmd, const char *name, int flags, in
   optarg->transient_mode = transient_mode;
   optarg->flags = flags;
 
-  if (lastopt) lastopt->next = optarg;
-  else         cmd->optargs = optarg;
+  if (lastopt)
+    lastopt->next = optarg;
+  else
+    cmd->optargs = optarg;
   cli_optarg_build_shortest(cmd->optargs);
   retval = CLI_OK;
-  
+
 CLEANUP:
   if (retval != CLI_OK) {
     cli_free_optarg(optarg);
@@ -2164,44 +2161,42 @@ int cli_unregister_optarg(struct cli_command *cmd, const char *name) {
   struct cli_optarg *lastptr;
   int retval = CLI_ERROR;
   // iterate looking for this option name, stoping at end or if name matches
-  for (lastptr=NULL, ptr=cmd->optargs; ptr && strcmp(ptr->name, name); lastptr=ptr, ptr=ptr->next)
-  {
+  for (lastptr = NULL, ptr = cmd->optargs; ptr && strcmp(ptr->name, name); lastptr = ptr, ptr = ptr->next) {
     ;
   }
-  
+
   // if ptr, then we found the optarg to delete
   if (ptr) {
     if (lastptr) {
       // not first optarg
       lastptr->next = ptr->next;
-      ptr->next=NULL;
-    }
-    else {
+      ptr->next = NULL;
+    } else {
       // first optarg
       cmd->optargs = ptr->next;
-      ptr->next=NULL;
+      ptr->next = NULL;
     }
     cli_free_optarg(ptr);
     cli_optarg_build_shortest(cmd->optargs);
-    retval = CLI_OK;  
-  }  
+    retval = CLI_OK;
+  }
   return retval;
-}  
+}
 
 void cli_unregister_all_optarg(struct cli_optarg *optarg) {
   struct cli_optarg *p;
-  
-  for (;optarg; optarg=p) {
-    p=optarg->next;
-    cli_free_optarg(optarg);    
+
+  for (; optarg; optarg = p) {
+    p = optarg->next;
+    cli_free_optarg(optarg);
   }
 }
 
 void cli_int_unset_optarg_value(struct cli_def *cli, const char *name) {
-  struct cli_optarg_pair **p,*c;
-  for (p=&cli->found_optargs, c=*p ; *p; ) {
-    c=*p;
-    
+  struct cli_optarg_pair **p, *c;
+  for (p = &cli->found_optargs, c = *p; *p;) {
+    c = *p;
+
     if (!strcmp(c->name, name)) {
       *p = c->next;
       free_z(c->name);
@@ -2216,8 +2211,9 @@ void cli_int_unset_optarg_value(struct cli_def *cli, const char *name) {
 int cli_int_add_optarg_value(struct cli_def *cli, const char *name, const char *value, int allow_multiple) {
   struct cli_optarg_pair *optarg_pair, **anchor;
   int rc = CLI_ERROR;
-  
-  for (optarg_pair=cli->found_optargs, anchor=&cli->found_optargs; optarg_pair ; anchor = &optarg_pair->next, optarg_pair=optarg_pair->next) {
+
+  for (optarg_pair = cli->found_optargs, anchor = &cli->found_optargs; optarg_pair;
+       anchor = &optarg_pair->next, optarg_pair = optarg_pair->next) {
     // break if we found this name *and* allow_multiple is false
     if (!strcmp(optarg_pair->name, name) && !allow_multiple) {
       break;
@@ -2225,45 +2221,44 @@ int cli_int_add_optarg_value(struct cli_def *cli, const char *name, const char *
   }
   // if we *didn't* find this, then allocate a new entry before proceeding
   if (!optarg_pair) {
-    optarg_pair = (struct cli_optarg_pair*)calloc(1,sizeof(struct cli_optarg_pair));
-     *anchor = optarg_pair;
+    optarg_pair = (struct cli_optarg_pair *)calloc(1, sizeof(struct cli_optarg_pair));
+    *anchor = optarg_pair;
   }
   // set the value
   if (optarg_pair) {
-      // name is null only if we didn't find it
-      if (!optarg_pair->name) optarg_pair->name=strdup(name);
+    // name is null only if we didn't find it
+    if (!optarg_pair->name) optarg_pair->name = strdup(name);
 
-      // value may be overwritten, so free any old value.
-      if ( optarg_pair->value) free_z(optarg_pair->value);
-      optarg_pair->value=strdup(value);
-      
-      rc=CLI_OK;
+    // value may be overwritten, so free any old value.
+    if (optarg_pair->value) free_z(optarg_pair->value);
+    optarg_pair->value = strdup(value);
+
+    rc = CLI_OK;
   }
   return rc;
 }
 
-struct cli_optarg_pair * cli_get_all_found_optargs(struct cli_def *cli) {
-  if (cli ) return cli->found_optargs;
+struct cli_optarg_pair *cli_get_all_found_optargs(struct cli_def *cli) {
+  if (cli) return cli->found_optargs;
   return NULL;
 }
 
-
-char * cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_after) {
-  char *value=NULL;
+char *cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_after) {
+  char *value = NULL;
   struct cli_optarg_pair *optarg_pair;
-  
-  printf("cli_get_optarg_value entry - looking for <%s> after <%p>\n", name, (void*)find_after);
-  for (optarg_pair = cli->found_optargs; !value && optarg_pair; optarg_pair=optarg_pair->next) {
-    printf("  Checking %s with value %s <%p> \n", optarg_pair->name, optarg_pair->value, (void*)optarg_pair->value);
-    
+
+  printf("cli_get_optarg_value entry - looking for <%s> after <%p>\n", name, (void *)find_after);
+  for (optarg_pair = cli->found_optargs; !value && optarg_pair; optarg_pair = optarg_pair->next) {
+    printf("  Checking %s with value %s <%p> \n", optarg_pair->name, optarg_pair->value, (void *)optarg_pair->value);
+
     // check next entry if this isn't our name
     if (strcasecmp(optarg_pair->name, name)) continue;
 
     // did we have a find_after, then ignore anything up until our find_after match
-    if ((find_after )&& (optarg_pair->value == find_after)) {
-      find_after=NULL;
+    if ((find_after) && (optarg_pair->value == find_after)) {
+      find_after = NULL;
       continue;
-    } else if ( !find_after) {
+    } else if (!find_after) {
       value = optarg_pair->value;
     }
   }
@@ -2271,9 +2266,7 @@ char * cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_af
   return value;
 }
 
-
-
-void cli_int_free_buildmode(struct cli_def *cli) {  
+void cli_int_free_buildmode(struct cli_def *cli) {
   if (!cli || !cli->buildmode) return;
   if (cli->buildmode->commands) cli_unregister_all(cli, cli->buildmode->commands);
   cli->mode = cli->buildmode->mode;
@@ -2286,16 +2279,15 @@ void cli_int_free_buildmode(struct cli_def *cli) {
 int cli_int_enter_buildmode(struct cli_def *cli, struct cli_pipeline_stage *stage, char *mode_text) {
   struct cli_optarg *optarg;
   struct cli_command *c;
-  struct cli_buildmode *buildmode ;
-  
+  struct cli_buildmode *buildmode;
 
-  if ( (!cli ) || !(buildmode=(struct cli_buildmode *)calloc(1,sizeof(struct cli_buildmode)))) {
+  if ((!cli) || !(buildmode = (struct cli_buildmode *)calloc(1, sizeof(struct cli_buildmode)))) {
     cli_error(cli, "Unable to build buildmode mode for command %s", stage->command->command);
     return CLI_BUILDMODE_COMMAND_ERROR;
   }
-  
+
   // clean up any shrapnel from earlier - shouldn't be any but....
-  if ( cli->buildmode) {
+  if (cli->buildmode) {
     cli_int_free_buildmode(cli);
   }
 
@@ -2307,43 +2299,53 @@ int cli_int_enter_buildmode(struct cli_def *cli, struct cli_pipeline_stage *stag
 
   // need this to verify we have all *required* arguments
   cli->buildmode->c = stage->command;
-  
+
   // build new *limited* list of commands from this commands optargs
-  for (optarg = stage->command->optargs; optarg ; optarg=optarg->next) {
+  for (optarg = stage->command->optargs; optarg; optarg = optarg->next) {
     // don't allow anything that could redefine our mode or buildmode mode, or redefine exit/cancel
-    if (!strcmp(optarg->name,"cancel") || (!strcmp(optarg->name, "exit"))) {
+    if (!strcmp(optarg->name, "cancel") || (!strcmp(optarg->name, "exit"))) {
       cli_error(cli, "Unable to build buildmode mode from optarg named %s", optarg->name);
       return CLI_BUILDMODE_COMMAND_ERROR;
     }
-    if (optarg->flags&(CLI_CMD_ALLOW_BUILDMODE | CLI_CMD_TRANSIENT_MODE)) continue;
-    if (optarg->mode != cli->mode && optarg->mode != cli->transient_mode) continue;
-    else if (optarg->flags & ( CLI_CMD_OPTIONAL_ARGUMENT|CLI_CMD_ARGUMENT)) {
-      if ((c=cli_int_register_buildmode_command(cli, NULL, optarg->name, cli_int_buildmode_cmd_cback, optarg->privilege, cli->mode, optarg->help))) {
-        cli_register_optarg(c, optarg->name, CLI_CMD_ARGUMENT|(optarg->flags&CLI_CMD_OPTION_MULTIPLE), optarg->privilege, cli->mode, optarg->help, optarg->get_completions, optarg->validator, NULL);
-      }
-      else {
+    if (optarg->flags & (CLI_CMD_ALLOW_BUILDMODE | CLI_CMD_TRANSIENT_MODE)) continue;
+    if (optarg->mode != cli->mode && optarg->mode != cli->transient_mode)
+      continue;
+    else if (optarg->flags & (CLI_CMD_OPTIONAL_ARGUMENT | CLI_CMD_ARGUMENT)) {
+      if ((c = cli_int_register_buildmode_command(cli, NULL, optarg->name, cli_int_buildmode_cmd_cback,
+                                                  optarg->privilege, cli->mode, optarg->help))) {
+        cli_register_optarg(c, optarg->name, CLI_CMD_ARGUMENT | (optarg->flags & CLI_CMD_OPTION_MULTIPLE),
+                            optarg->privilege, cli->mode, optarg->help, optarg->get_completions, optarg->validator,
+                            NULL);
+      } else {
         return CLI_BUILDMODE_COMMAND_ERROR;
       }
     } else {
-      if (optarg->flags&CLI_CMD_OPTION_MULTIPLE) {
-        if (!cli_int_register_buildmode_command(cli, NULL, optarg->name, cli_int_buildmode_flag_multiple_cback, optarg->privilege, cli->mode, optarg->help)) {
+      if (optarg->flags & CLI_CMD_OPTION_MULTIPLE) {
+        if (!cli_int_register_buildmode_command(cli, NULL, optarg->name, cli_int_buildmode_flag_multiple_cback,
+                                                optarg->privilege, cli->mode, optarg->help)) {
           return CLI_BUILDMODE_COMMAND_ERROR;
         }
       } else {
-         if (!cli_int_register_buildmode_command(cli, NULL, optarg->name, cli_int_buildmode_flag_cback, optarg->privilege, cli->mode, optarg->help)) {
+        if (!cli_int_register_buildmode_command(cli, NULL, optarg->name, cli_int_buildmode_flag_cback,
+                                                optarg->privilege, cli->mode, optarg->help)) {
           return CLI_BUILDMODE_COMMAND_ERROR;
-         }
+        }
       }
     }
   }
   cli->buildmode->cname = strdup(cli_command_name(cli, stage->command));
   // and lastly two 'always there' commands to cancel current mode and to execute the command
-  cli_int_register_buildmode_command(cli, NULL, "cancel", cli_int_buildmode_cancel_cback, PRIVILEGE_UNPRIVILEGED, cli->mode, "Cancel command");
-  cli_int_register_buildmode_command(cli, NULL, "exit", cli_int_buildmode_exit_cback, PRIVILEGE_UNPRIVILEGED, cli->mode, "Exit and execute command");
-  cli_int_register_buildmode_command(cli, NULL, "show", cli_int_buildmode_show_cback, PRIVILEGE_UNPRIVILEGED, cli->mode, "Show current settings");
-  c=cli_int_register_buildmode_command(cli, NULL, "unset", cli_int_buildmode_unset_cback, PRIVILEGE_UNPRIVILEGED, cli->mode, "Unset a setting");
-        cli_register_optarg(c, "setting", CLI_CMD_ARGUMENT|CLI_CMD_DO_NOT_RECORD, PRIVILEGE_UNPRIVILEGED, cli->mode, "setting to clear", cli_int_buildmode_unset_completor, cli_int_buildmode_unset_validator, NULL);
-  
+  cli_int_register_buildmode_command(cli, NULL, "cancel", cli_int_buildmode_cancel_cback, PRIVILEGE_UNPRIVILEGED,
+                                     cli->mode, "Cancel command");
+  cli_int_register_buildmode_command(cli, NULL, "exit", cli_int_buildmode_exit_cback, PRIVILEGE_UNPRIVILEGED, cli->mode,
+                                     "Exit and execute command");
+  cli_int_register_buildmode_command(cli, NULL, "show", cli_int_buildmode_show_cback, PRIVILEGE_UNPRIVILEGED, cli->mode,
+                                     "Show current settings");
+  c = cli_int_register_buildmode_command(cli, NULL, "unset", cli_int_buildmode_unset_cback, PRIVILEGE_UNPRIVILEGED,
+                                         cli->mode, "Unset a setting");
+  cli_register_optarg(c, "setting", CLI_CMD_ARGUMENT | CLI_CMD_DO_NOT_RECORD, PRIVILEGE_UNPRIVILEGED, cli->mode,
+                      "setting to clear", cli_int_buildmode_unset_completor, cli_int_buildmode_unset_validator, NULL);
+
   cli_build_shortest(cli, cli->buildmode->commands);
 
   return CLI_BUILDMODE_COMMAND_START;
@@ -2371,11 +2373,12 @@ int cli_int_unregister_buildmode_command(struct cli_def *cli, const char *comman
   return CLI_OK;
 }
 
-// a copy of cli_register_command, but using cli->buildmode_cmd rather than cli->commands as the anchor 
+// a copy of cli_register_command, but using cli->buildmode_cmd rather than cli->commands as the anchor
 
-struct cli_command *cli_int_register_buildmode_command(struct cli_def *cli, struct cli_command *parent, const char *command,
-                                         int (*callback)(struct cli_def *cli, const char *, char **, int),
-                                         int privilege, int mode, const char *help) {
+struct cli_command *cli_int_register_buildmode_command(struct cli_def *cli, struct cli_command *parent,
+                                                       const char *command,
+                                                       int (*callback)(struct cli_def *cli, const char *, char **, int),
+                                                       int privilege, int mode, const char *help) {
   struct cli_command *c, *p;
 
   if (!command) return NULL;
@@ -2418,85 +2421,83 @@ struct cli_command *cli_int_register_buildmode_command(struct cli_def *cli, stru
 }
 
 int cli_int_execute_buildmode(struct cli_def *cli) {
-  struct cli_optarg *optarg=NULL;
+  struct cli_optarg *optarg = NULL;
   int rc = CLI_OK;
   char *cmdline;
-  
-  char *value=NULL;
-  
-  cmdline = strdup(cli_command_name(cli,cli->buildmode->c));
-  for (optarg=cli->buildmode->c->optargs; rc==CLI_OK && optarg;optarg=optarg->next) {
-    value=NULL;
+
+  char *value = NULL;
+
+  cmdline = strdup(cli_command_name(cli, cli->buildmode->c));
+  for (optarg = cli->buildmode->c->optargs; rc == CLI_OK && optarg; optarg = optarg->next) {
+    value = NULL;
     do {
       if (cli->privilege < optarg->privilege) continue;
-      if ((optarg->mode!=cli->buildmode->mode) && (optarg->mode != cli->buildmode->transient_mode) && (optarg->mode != MODE_ANY)) continue;
-      
-      value = cli_get_optarg_value(cli,optarg->name,value);
+      if ((optarg->mode != cli->buildmode->mode) && (optarg->mode != cli->buildmode->transient_mode) &&
+          (optarg->mode != MODE_ANY))
+        continue;
+
+      value = cli_get_optarg_value(cli, optarg->name, value);
       if (!value && optarg->flags & CLI_CMD_ARGUMENT) {
-        cli_error(cli,"Missing required argument %s", optarg->name);
-        rc=CLI_MISSING_ARGUMENT;
-      }
-      else if (value) {
+        cli_error(cli, "Missing required argument %s", optarg->name);
+        rc = CLI_MISSING_ARGUMENT;
+      } else if (value) {
         if (optarg->flags & (CLI_CMD_OPTIONAL_FLAG | CLI_CMD_ARGUMENT)) {
-          if (!(cmdline=cli_int_buildmode_extend_cmdline(cmdline,value))) {
-            cli_error(cli,"Unable to append to building commandlne");
-            rc=CLI_ERROR;
+          if (!(cmdline = cli_int_buildmode_extend_cmdline(cmdline, value))) {
+            cli_error(cli, "Unable to append to building commandlne");
+            rc = CLI_ERROR;
           }
         } else {
-          if (!(cmdline=cli_int_buildmode_extend_cmdline(cmdline,optarg->name))) {
-            cli_error(cli,"Unable to append to building commandlne");
-            rc=CLI_ERROR;
+          if (!(cmdline = cli_int_buildmode_extend_cmdline(cmdline, optarg->name))) {
+            cli_error(cli, "Unable to append to building commandlne");
+            rc = CLI_ERROR;
           }
-          if (!(cmdline=cli_int_buildmode_extend_cmdline(cmdline,value))) {
-            cli_error(cli,"Unable to append to building commandlne");
-            rc=CLI_ERROR;
+          if (!(cmdline = cli_int_buildmode_extend_cmdline(cmdline, value))) {
+            cli_error(cli, "Unable to append to building commandlne");
+            rc = CLI_ERROR;
           }
         }
       }
-    } while (rc==CLI_OK && value && optarg->flags & CLI_CMD_OPTION_MULTIPLE);
+    } while (rc == CLI_OK && value && optarg->flags & CLI_CMD_OPTION_MULTIPLE);
   }
-  
-  if (rc==CLI_OK) {
+
+  if (rc == CLI_OK) {
     cli_int_free_buildmode(cli);
     cli_add_history(cli, cmdline);
-    rc = cli_run_command(cli, cmdline);        
+    rc = cli_run_command(cli, cmdline);
   }
   free_z(cmdline);
   cli_int_free_buildmode(cli);
   return rc;
 }
 
+char *cli_int_buildmode_extend_cmdline(char *cmdline, char *word) {
+  char *tptr = NULL;
+  char *cptr = NULL;
+  size_t oldlen = strlen(cmdline);
+  size_t wordlen = strlen(word);
+  int add_quotes = 0;
 
-
-char * cli_int_buildmode_extend_cmdline(char *cmdline, char *word) {
-  char *tptr=NULL;
-  char *cptr=NULL;
-  size_t oldlen=strlen(cmdline);
-  size_t wordlen=strlen(word);
-  int add_quotes=0;
-  
   /*
    * Allocate enough space to hold the old string, a space, and the new string (including null terminator).
    * Also include enough space for a quote around the string if it contains a whitespace character
    */
-  if ( (tptr=(char*)realloc(cmdline, oldlen+1+wordlen+1+2)) ) {
-    strcat(tptr," ");
-    for (cptr=word;*cptr;cptr++) {
+  if ((tptr = (char *)realloc(cmdline, oldlen + 1 + wordlen + 1 + 2))) {
+    strcat(tptr, " ");
+    for (cptr = word; *cptr; cptr++) {
       if (isspace(*cptr)) {
-        add_quotes=1;
+        add_quotes = 1;
         break;
       }
-    }  
-    if (add_quotes) strcat(tptr,"'");
-    strcat(tptr,word);
-    if (add_quotes) strcat(tptr,"'");
+    }
+    if (add_quotes) strcat(tptr, "'");
+    strcat(tptr, word);
+    if (add_quotes) strcat(tptr, "'");
   }
   return tptr;
 }
 
-
 int cli_int_buildmode_cmd_cback(struct cli_def *cli, const char *command, char *argv[], int argc) {
-  int rc=CLI_BUILDMODE_COMMAND_EXTEND;
+  int rc = CLI_BUILDMODE_COMMAND_EXTEND;
 
   if (argc) {
     cli_error(cli, "Extra arguments on command line, command ignored.");
@@ -2507,14 +2508,14 @@ int cli_int_buildmode_cmd_cback(struct cli_def *cli, const char *command, char *
 
 // a 'flag' callback has no optargs, so we need to set it ourself based on *this* command
 int cli_int_buildmode_flag_cback(struct cli_def *cli, const char *command, char *argv[], int argc) {
-  int rc=CLI_BUILDMODE_COMMAND_EXTEND;
+  int rc = CLI_BUILDMODE_COMMAND_EXTEND;
 
   if (argc) {
     cli_error(cli, "Extra arguments on command line, command ignored.");
     rc = CLI_ERROR;
   }
   if (cli_int_add_optarg_value(cli, command, command, 0)) {
-    cli_error(cli,"Problem setting value for optional flag %s",  command);
+    cli_error(cli, "Problem setting value for optional flag %s", command);
     rc = CLI_ERROR;
   }
   return rc;
@@ -2522,48 +2523,47 @@ int cli_int_buildmode_flag_cback(struct cli_def *cli, const char *command, char 
 
 // a 'flag' callback has no optargs, so we need to set it ourself based on *this* command
 int cli_int_buildmode_flag_multiple_cback(struct cli_def *cli, const char *command, char *argv[], int argc) {
-  int rc=CLI_BUILDMODE_COMMAND_EXTEND;
+  int rc = CLI_BUILDMODE_COMMAND_EXTEND;
 
   if (argc) {
     cli_error(cli, "Extra arguments on command line, command ignored.");
     rc = CLI_ERROR;
   }
   if (cli_int_add_optarg_value(cli, command, command, CLI_CMD_OPTION_MULTIPLE)) {
-    cli_error(cli,"Problem setting value for optional flag %s",  command);
+    cli_error(cli, "Problem setting value for optional flag %s", command);
     rc = CLI_ERROR;
   }
-  
+
   return rc;
 }
 
 int cli_int_buildmode_cancel_cback(struct cli_def *cli, const char *command, char *argv[], int argc) {
-  int rc= CLI_BUILDMODE_COMMAND_CANCEL;
+  int rc = CLI_BUILDMODE_COMMAND_CANCEL;
 
-  if (argc>0) {
+  if (argc > 0) {
     cli_error(cli, "Extra arguments on command line, command ignored.");
-    rc=CLI_ERROR;
+    rc = CLI_ERROR;
   }
   return rc;
 }
 
 int cli_int_buildmode_exit_cback(struct cli_def *cli, const char *command, char *argv[], int argc) {
-  int rc= CLI_BUILDMODE_COMMAND_EXIT;
+  int rc = CLI_BUILDMODE_COMMAND_EXIT;
 
-  if (argc>0) {
+  if (argc > 0) {
     cli_error(cli, "Extra arguments on command line, command ignored.");
-    rc=CLI_ERROR;
+    rc = CLI_ERROR;
   }
   return rc;
 }
 
 int cli_int_buildmode_show_cback(struct cli_def *cli, const char *command, char *argv[], int argc) {
-  struct cli_optarg_pair *optarg_pair;  
-  if (cli && cli->buildmode ){
-    for (optarg_pair=cli->found_optargs; optarg_pair; optarg_pair=optarg_pair->next)
-    {
+  struct cli_optarg_pair *optarg_pair;
+  if (cli && cli->buildmode) {
+    for (optarg_pair = cli->found_optargs; optarg_pair; optarg_pair = optarg_pair->next) {
       // only show vars that are also current 'commands'
       struct cli_command *c = cli->buildmode->commands;
-      for (;c ; c=c->next) {
+      for (; c; c = c->next) {
         if (!strcmp(c->command, optarg_pair->name)) {
           cli_print(cli, "  %-20s = %s", optarg_pair->name, optarg_pair->value);
           break;
@@ -2576,48 +2576,44 @@ int cli_int_buildmode_show_cback(struct cli_def *cli, const char *command, char 
 
 int cli_int_buildmode_unset_cback(struct cli_def *cli, const char *command, char *argv[], int argc) {
   // iterate over our 'set' variables to see if that variable is also a 'valid' command right now
-  
+
   struct cli_command *c;
-  
+
   // is this 'optarg' to remove one of the current commands?
-  for (c=cli->buildmode->commands; c; c=c->next) {
+  for (c = cli->buildmode->commands; c; c = c->next) {
     if (cli->privilege < c->privilege) continue;
-    if ((cli->buildmode->mode!=c->mode) && (cli->buildmode->transient_mode != c->mode) && (c->mode != MODE_ANY)) continue;
+    if ((cli->buildmode->mode != c->mode) && (cli->buildmode->transient_mode != c->mode) && (c->mode != MODE_ANY))
+      continue;
     if (strcmp(c->command, argv[0])) continue;
-      // Ok, go fry anything by this name
-    
+    // Ok, go fry anything by this name
+
     cli_int_unset_optarg_value(cli, argv[0]);
     break;
   }
- 
+
   return CLI_OK;
 }
 
 /* Generate a list of variables that *have* been set */
-int cli_int_buildmode_unset_completor(struct cli_def *cli, const char *name, const char *word, struct cli_comphelp *comphelp) {
+int cli_int_buildmode_unset_completor(struct cli_def *cli, const char *name, const char *word,
+                                      struct cli_comphelp *comphelp) {
   return CLI_OK;
 }
 
-int cli_int_buildmode_unset_validator(struct cli_def *cli, const char *name, const char *value) {
-  return CLI_OK;
-}
+int cli_int_buildmode_unset_validator(struct cli_def *cli, const char *name, const char *value) { return CLI_OK; }
 
-
-void cli_set_transient_mode(struct cli_def *cli, int transient_mode) {
-  cli->transient_mode = transient_mode;
-}
+void cli_set_transient_mode(struct cli_def *cli, int transient_mode) { cli->transient_mode = transient_mode; }
 
 int cli_add_comphelp_entry(struct cli_comphelp *comphelp, const char *entry) {
   int retval = CLI_ERROR;
   if (comphelp && entry) {
     char *dupelement = strdup(entry);
-    char **duparray = (char **)realloc((void*)comphelp->entries, sizeof(char *)*(comphelp->num_entries+1));
+    char **duparray = (char **)realloc((void *)comphelp->entries, sizeof(char *) * (comphelp->num_entries + 1));
     if (dupelement && duparray) {
-      comphelp->entries=duparray;
+      comphelp->entries = duparray;
       comphelp->entries[comphelp->num_entries++] = dupelement;
       retval = CLI_OK;
-    }
-    else {
+    } else {
       free_z(dupelement);
       free_z(duparray);
     }
@@ -2628,14 +2624,14 @@ int cli_add_comphelp_entry(struct cli_comphelp *comphelp, const char *entry) {
 void cli_free_comphelp(struct cli_comphelp *comphelp) {
   if (comphelp) {
     int idx;
-    
-    for (idx=0;idx<comphelp->num_entries;idx++) free_z(comphelp->entries[idx]);
+
+    for (idx = 0; idx < comphelp->num_entries; idx++) free_z(comphelp->entries[idx]);
     free_z(comphelp->entries);
   }
 }
 
-static int cli_int_locate_command(struct cli_def *cli, struct cli_command *commands,
-                            int start_word, struct cli_pipeline_stage *stage) {
+static int cli_int_locate_command(struct cli_def *cli, struct cli_command *commands, int start_word,
+                                  struct cli_pipeline_stage *stage) {
   struct cli_command *c, *again_config = NULL, *again_any = NULL;
   int c_words = stage->num_words;
 
@@ -2681,11 +2677,10 @@ static int cli_int_locate_command(struct cli_def *cli, struct cli_command *comma
         return CLI_ERROR;
       }
 
-    
     CORRECT_CHECKS:
 
       if (rc == CLI_OK) {
-        
+
         stage->command = c;
         stage->first_unmatched = start_word + 1;
         stage->first_optarg = stage->first_unmatched;
@@ -2723,72 +2718,73 @@ static int cli_int_locate_command(struct cli_def *cli, struct cli_command *comma
 int cli_int_validate_pipeline(struct cli_def *cli, struct cli_pipeline *pipeline) {
 
   int i;
-  int rc=CLI_OK;
+  int rc = CLI_OK;
 
-  struct cli_command *first_command=NULL;
-  cli->found_optargs=NULL;
+  struct cli_command *first_command = NULL;
+  cli->found_optargs = NULL;
   if (cli->buildmode && cli->buildmode->commands) {
     first_command = cli->buildmode->commands;
   } else {
     first_command = cli->commands;
   }
-  for (i=0;i<pipeline->num_stages;i++) {    
+  for (i = 0; i < pipeline->num_stages; i++) {
     // in 'buildmode' we only have one pipeline, but we need to recall if we had started with any optargs
 
-    if (cli->buildmode) cli->found_optargs = cli->buildmode->found_optargs;
-    else		cli->found_optargs = NULL;
-    rc=cli_int_locate_command(cli, (i==0)?first_command:cli->filter_commands, 0, &pipeline->stage[i]);
-    
+    if (cli->buildmode)
+      cli->found_optargs = cli->buildmode->found_optargs;
+    else
+      cli->found_optargs = NULL;
+    rc = cli_int_locate_command(cli, (i == 0) ? first_command : cli->filter_commands, 0, &pipeline->stage[i]);
+
     // and save our found optargs for later use
 
-    if (cli->buildmode) cli->buildmode->found_optargs = cli->found_optargs;
-    else                pipeline->stage[i].found_optargs = cli->found_optargs;
+    if (cli->buildmode)
+      cli->buildmode->found_optargs = cli->found_optargs;
+    else
+      pipeline->stage[i].found_optargs = cli->found_optargs;
 
-    if (rc!=CLI_OK) break;
+    if (rc != CLI_OK) break;
   }
   return rc;
 }
 
-
-
 struct cli_pipeline *cli_int_free_pipeline(struct cli_pipeline *pipeline) {
   int i;
   if (pipeline) {
-    for (i=0;i<pipeline->num_stages;i++) cli_int_free_found_optargs(&pipeline->stage[i].found_optargs);
-    for (i=0;i<pipeline->num_words;i++) free_z(pipeline->words[i]);
+    for (i = 0; i < pipeline->num_stages; i++) cli_int_free_found_optargs(&pipeline->stage[i].found_optargs);
+    for (i = 0; i < pipeline->num_words; i++) free_z(pipeline->words[i]);
     free_z(pipeline->cmdline);
     free_z(pipeline);
-    pipeline=NULL;
+    pipeline = NULL;
   }
   return pipeline;
 }
 
 void cli_int_show_pipeline(struct cli_def *cli, struct cli_pipeline *pipeline) {
-  int i,j;
-  struct cli_pipeline_stage* stage;
+  int i, j;
+  struct cli_pipeline_stage *stage;
   char **word;
   struct cli_optarg_pair *optarg_pair;
-  
-  for (i=0,word=pipeline->words;i<pipeline->num_words;i++,word++) printf("[%s] ",*word);
+
+  for (i = 0, word = pipeline->words; i < pipeline->num_words; i++, word++) printf("[%s] ", *word);
   printf("\n");
-  printf( "#stages=%d, #words=%d\n", pipeline->num_stages, pipeline->num_words);
-  
-  for (i=0;i<pipeline->num_stages;i++) {
-    stage=&(pipeline->stage[i]);
-    printf( "  #%d(%d words) first_unmatched=%d: " , i, stage->num_words, stage->first_unmatched);
-    for (j=0; j<stage->num_words;j++) {
-      printf(" [%s]",stage->words[j]);
+  printf("#stages=%d, #words=%d\n", pipeline->num_stages, pipeline->num_words);
+
+  for (i = 0; i < pipeline->num_stages; i++) {
+    stage = &(pipeline->stage[i]);
+    printf("  #%d(%d words) first_unmatched=%d: ", i, stage->num_words, stage->first_unmatched);
+    for (j = 0; j < stage->num_words; j++) {
+      printf(" [%s]", stage->words[j]);
     }
     printf("\n");
 
     if (stage->command) {
       printf("  Command: %s\n", stage->command->command);
     }
-    for (optarg_pair = stage->found_optargs; optarg_pair; optarg_pair=optarg_pair->next) {
+    for (optarg_pair = stage->found_optargs; optarg_pair; optarg_pair = optarg_pair->next) {
       printf("    %s: %s\n", optarg_pair->name, optarg_pair->value);
     }
-
-  }  
+  }
 }
 
 /*
@@ -2799,25 +2795,25 @@ struct cli_pipeline *cli_int_generate_pipeline(struct cli_def *cli, const char *
   int i;
   struct cli_pipeline_stage *stage;
   char **word;
-  struct cli_pipeline *pipeline=NULL;
-  
-  cli->found_optargs=NULL;
+  struct cli_pipeline *pipeline = NULL;
+
+  cli->found_optargs = NULL;
   if (cli->buildmode) cli->found_optargs = cli->buildmode->found_optargs;
   if (!command) return NULL;
   while (*command && isspace(*command)) command++;
-  
+
   if (!(pipeline = (struct cli_pipeline *)calloc(1, sizeof(struct cli_pipeline)))) return NULL;
-  pipeline->cmdline=(char*)strdup(command);
-  
+  pipeline->cmdline = (char *)strdup(command);
+
   pipeline->num_words = cli_parse_line(command, pipeline->words, CLI_MAX_LINE_WORDS);
 
-  pipeline->stage[0].num_words=0;
-  stage=&pipeline->stage[0];
+  pipeline->stage[0].num_words = 0;
+  stage = &pipeline->stage[0];
   word = pipeline->words;
   stage->words = word;
-  for (i=0 ; i < pipeline->num_words ; i++, word++) {
+  for (i = 0; i < pipeline->num_words; i++, word++) {
     if (*word[0] == '|') {
-      if (cli->buildmode ) {
+      if (cli->buildmode) {
         // can't allow filters in buildmode commands
         cli_int_free_pipeline(pipeline);
         return NULL;
@@ -2826,88 +2822,90 @@ struct cli_pipeline *cli_int_generate_pipeline(struct cli_def *cli, const char *
       stage++;
       stage->num_words = 0;
       pipeline->num_stages++;
-      stage->words = word+1;  // first word of the next stage is one past where we are (possibly NULL)
-    }
-    else
-    {
+      stage->words = word + 1;  // first word of the next stage is one past where we are (possibly NULL)
+    } else {
       stage->num_words++;
     }
   }
-  stage->stage_num=pipeline->num_stages;
+  stage->stage_num = pipeline->num_stages;
   pipeline->num_stages++;
   return pipeline;
 }
 
-int cli_int_execute_pipeline (struct cli_def *cli, struct cli_pipeline *pipeline) {
+int cli_int_execute_pipeline(struct cli_def *cli, struct cli_pipeline *pipeline) {
   int stage_num;
-  int rc=CLI_OK;
+  int rc = CLI_OK;
   struct cli_filter **filt = &cli->filters;
 
   if (pipeline) {
-    for (stage_num=1;stage_num<pipeline->num_stages;stage_num++) {
-      struct cli_pipeline_stage *stage=&pipeline->stage[stage_num];
+    for (stage_num = 1; stage_num < pipeline->num_stages; stage_num++) {
+      struct cli_pipeline_stage *stage = &pipeline->stage[stage_num];
       cli->found_optargs = stage->found_optargs;
-      *filt=calloc(sizeof(struct cli_filter), 1);
+      *filt = calloc(sizeof(struct cli_filter), 1);
       if (*filt) {
-        if ((rc=stage->command->init(cli, stage->num_words, stage->words, *filt)!=CLI_OK)) {
+        if ((rc = stage->command->init(cli, stage->num_words, stage->words, *filt) != CLI_OK)) {
           break;
         }
-        filt = &(*filt)->next; 
+        filt = &(*filt)->next;
       }
     }
-  
-  // Did everything init?  If so, execute, otherwise skip execution
-    if ( (rc==CLI_OK) && pipeline->stage[0].command->callback) {
-      struct cli_pipeline_stage *stage=&pipeline->stage[0];
-      
-      if (cli->buildmode) cli->found_optargs = cli->buildmode->found_optargs;
-      else                cli->found_optargs = pipeline->stage[0].found_optargs;
-      rc=stage->command->callback(cli, cli_command_name(cli, stage->command), stage->words+stage->first_unmatched, stage->num_words - stage->first_unmatched);
-      if (cli->buildmode) cli->buildmode->found_optargs = cli->found_optargs ;
+
+    // Did everything init?  If so, execute, otherwise skip execution
+    if ((rc == CLI_OK) && pipeline->stage[0].command->callback) {
+      struct cli_pipeline_stage *stage = &pipeline->stage[0];
+
+      if (cli->buildmode)
+        cli->found_optargs = cli->buildmode->found_optargs;
+      else
+        cli->found_optargs = pipeline->stage[0].found_optargs;
+      rc = stage->command->callback(cli, cli_command_name(cli, stage->command), stage->words + stage->first_unmatched,
+                                    stage->num_words - stage->first_unmatched);
+      if (cli->buildmode) cli->buildmode->found_optargs = cli->found_optargs;
     }
   }
-  // Now teardown any filters 
+  // Now teardown any filters
   while (cli->filters) {
     struct cli_filter *filt = cli->filters;
     if (filt->filter) filt->filter(cli, NULL, cli->filters->data);
-    cli->filters=filt->next;
+    cli->filters = filt->next;
     free_z(filt);
   }
-  cli->found_optargs=NULL;
+  cli->found_optargs = NULL;
   return rc;
 }
 
-static char DELIM_OPT_START[]="[";
-static char DELIM_OPT_END[]="]";
-static char DELIM_ARG_START[]="<";
-static char DELIM_ARG_END[]=">";
-static char DELIM_NONE[]="";
+static char DELIM_OPT_START[] = "[";
+static char DELIM_OPT_END[] = "]";
+static char DELIM_ARG_START[] = "<";
+static char DELIM_ARG_END[] = ">";
+static char DELIM_NONE[] = "";
 static char BUILDMODE_YES[] = " (enter buildmode)";
 static char BUILDMODE_NO[] = "";
 
-static void cli_get_optarg_comphelp(struct cli_def *cli, struct cli_optarg *optarg, struct cli_comphelp *comphelp, 
-                                    int num_candidates, const char lastchar, const char *anchor_word, const char *next_word) {
-  int help_insert=0;
-  char *delim_start=DELIM_NONE;
-  
-  char *delim_end=DELIM_NONE;
-  char *allow_buildmode=BUILDMODE_NO;
+static void cli_get_optarg_comphelp(struct cli_def *cli, struct cli_optarg *optarg, struct cli_comphelp *comphelp,
+                                    int num_candidates, const char lastchar, const char *anchor_word,
+                                    const char *next_word) {
+  int help_insert = 0;
+  char *delim_start = DELIM_NONE;
+
+  char *delim_end = DELIM_NONE;
+  char *allow_buildmode = BUILDMODE_NO;
   int (*get_completions)(struct cli_def *, const char *, const char *, struct cli_comphelp *) = NULL;
-  char *tptr=NULL;
-   
+  char *tptr = NULL;
+
   // if we've already seen a value by this exact name, skip it, unless the multiple flag is set
   if (cli_find_optarg_value(cli, optarg->name, NULL) && !(optarg->flags & (CLI_CMD_OPTION_MULTIPLE))) return;
 
   get_completions = optarg->get_completions;
   if (optarg->flags & CLI_CMD_OPTIONAL_FLAG) {
-    if (!( anchor_word && !strncmp(anchor_word, optarg->name, strlen(anchor_word)))) {
-      delim_start=DELIM_OPT_START;
-      delim_end=DELIM_OPT_END;
-      get_completions = NULL; // no point, completor of field is the name itself
+    if (!(anchor_word && !strncmp(anchor_word, optarg->name, strlen(anchor_word)))) {
+      delim_start = DELIM_OPT_START;
+      delim_end = DELIM_OPT_END;
+      get_completions = NULL;  // no point, completor of field is the name itself
     }
   } else if (optarg->flags & CLI_CMD_ARGUMENT) {
-    delim_start=DELIM_ARG_START;
-    delim_end=DELIM_ARG_END;
+    delim_start = DELIM_ARG_START;
+    delim_end = DELIM_ARG_END;
   } else if (optarg->flags & CLI_CMD_OPTIONAL_ARGUMENT) {
     /*
      * optional args can match against the name the value.
@@ -2915,102 +2913,103 @@ static void cli_get_optarg_comphelp(struct cli_def *cli, struct cli_optarg *opta
      * So if anchor_word==next_word we're looking at the 'name' of the optarg, otherwise we
      * know the name and are going against the value.
      */
-    if (anchor_word!=next_word) {
-      // matching against optional argument 'value' 
+    if (anchor_word != next_word) {
+      // matching against optional argument 'value'
       help_insert = 0;
       if (!get_completions) {
-        delim_start=DELIM_ARG_START;
-        delim_end=DELIM_ARG_END;
+        delim_start = DELIM_ARG_START;
+        delim_end = DELIM_ARG_END;
       }
     } else {
       // matching against optional argument 'name'
       help_insert = 1;
-      get_completions=NULL;  // matching against the name, not the following field value
-      if (!( anchor_word && !strncmp(anchor_word, optarg->name, strlen(anchor_word)))) {
-        delim_start=DELIM_OPT_START;
-        delim_end=DELIM_OPT_END;
+      get_completions = NULL;  // matching against the name, not the following field value
+      if (!(anchor_word && !strncmp(anchor_word, optarg->name, strlen(anchor_word)))) {
+        delim_start = DELIM_OPT_START;
+        delim_end = DELIM_OPT_END;
       }
     }
   }
 
   // Fill in with help text or completor value(s) as indicated
-  if ((lastchar == '?') && (asprintf(&tptr, "%s%s%s", delim_start,optarg->name,delim_end) != -1))  {
-    if (optarg->flags & CLI_CMD_ALLOW_BUILDMODE) allow_buildmode=BUILDMODE_YES;
-    if (help_insert && (asprintf(&tptr, "  %-20s enter '%s' to %s%s", tptr, optarg->name, (optarg->help)?optarg->help : "",allow_buildmode)!=-1)) {
+  if ((lastchar == '?') && (asprintf(&tptr, "%s%s%s", delim_start, optarg->name, delim_end) != -1)) {
+    if (optarg->flags & CLI_CMD_ALLOW_BUILDMODE) allow_buildmode = BUILDMODE_YES;
+    if (help_insert && (asprintf(&tptr, "  %-20s enter '%s' to %s%s", tptr, optarg->name,
+                                 (optarg->help) ? optarg->help : "", allow_buildmode) != -1)) {
       cli_add_comphelp_entry(comphelp, tptr);
-      free_z(tptr); 
-    }        
-    else if (asprintf(&tptr, "  %-20s %s%s", tptr,  (optarg->help)?optarg->help : "",allow_buildmode)!=-1) {
+      free_z(tptr);
+    } else if (asprintf(&tptr, "  %-20s %s%s", tptr, (optarg->help) ? optarg->help : "", allow_buildmode) != -1) {
       cli_add_comphelp_entry(comphelp, tptr);
-      free_z(tptr); 
-    }        
+      free_z(tptr);
+    }
   } else if (lastchar == CTRL('I')) {
     if (get_completions) {
-        (*get_completions)(cli, optarg->name, next_word, comphelp);
-    } else if ( (!anchor_word || !strncmp(anchor_word, optarg->name, strlen(anchor_word))) && (asprintf(&tptr, "%s%s%s", delim_start,optarg->name,delim_end) != -1)) {
-        cli_add_comphelp_entry(comphelp, tptr);
-        free_z(tptr);
+      (*get_completions)(cli, optarg->name, next_word, comphelp);
+    } else if ((!anchor_word || !strncmp(anchor_word, optarg->name, strlen(anchor_word))) &&
+               (asprintf(&tptr, "%s%s%s", delim_start, optarg->name, delim_end) != -1)) {
+      cli_add_comphelp_entry(comphelp, tptr);
+      free_z(tptr);
     }
   }
 }
 
-
-static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage *stage, struct cli_command *cmd, char lastchar, struct cli_comphelp *comphelp) {
-  struct cli_optarg *optarg=NULL, *oaptr=NULL;
-  int w_idx; // word_index
-  int w_incr; // word_increment
+static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage *stage, struct cli_command *cmd,
+                                  char lastchar, struct cli_comphelp *comphelp) {
+  struct cli_optarg *optarg = NULL, *oaptr = NULL;
+  int w_idx;   // word_index
+  int w_incr;  // word_increment
   struct cli_optarg *candidates[CLI_MAX_LINE_WORDS];
-  int num_candidates=0;
-  int c_idx; // candidate_idx
+  int num_candidates = 0;
+  int c_idx;  // candidate_idx
   char *value;
-  int is_last_word=0;
-  int (*validator)(struct cli_def*,const char *name, const char *value);
+  int is_last_word = 0;
+  int (*validator)(struct cli_def *, const char * name, const char * value);
 
   /*
-   * Tab completion and help are *only* allowed at end of string, but we need to process the entire command to 
+   * Tab completion and help are *only* allowed at end of string, but we need to process the entire command to
    * know what has already been found.  There should be no ambiguities before the 'last' word.
-   * Note specifically that for tab completions and help the *last* word can be a null pointer. 
+   * Note specifically that for tab completions and help the *last* word can be a null pointer.
    */
-  stage->error_word=NULL;
+  stage->error_word = NULL;
 
   /* start our optarg and word pointers at the beginning
    * optarg will be incremented *only* when an argument is identified
    * w_idx will be incremented either by 1 (optflag or argument) or 2 (optional argument)
    */
-  w_idx=stage->first_unmatched;
-  optarg=cmd->optargs;
-  num_candidates=0;
-  while (optarg && w_idx<stage->num_words  && (num_candidates <=1)) {
-    num_candidates=0;
+  w_idx = stage->first_unmatched;
+  optarg = cmd->optargs;
+  num_candidates = 0;
+  while (optarg && w_idx < stage->num_words && (num_candidates <= 1)) {
+    num_candidates = 0;
     w_incr = 1;  // assume we're only incrementing by a word - if we match an optional argument bump to 2
-    
+
     /* the initial loop here is to identify candidates based matching *this* word in order against:
      *    an exact match of the word to the optinal flag/argument name (yield exactly one match and exit the loop)
      *    a partial match for optional flag/argument name
      *    candidate an argument.
      */
-     
-    for (oaptr=optarg;oaptr;oaptr=oaptr->next) {
+
+    for (oaptr = optarg; oaptr; oaptr = oaptr->next) {
       // Skip this option unless it matches privileges, MODE_ANY, the current mode, or the transient_mode
       if (cli->privilege < oaptr->privilege) continue;
-      if ((oaptr->mode!=cli->mode) && (oaptr->mode != cli->transient_mode) && (oaptr->mode != MODE_ANY)) continue;
-      
+      if ((oaptr->mode != cli->mode) && (oaptr->mode != cli->transient_mode) && (oaptr->mode != MODE_ANY)) continue;
 
       /* An exact match for an optional flag/argument name trumps anything and will be the *only* candidate
        * Otherwise if the word is 'blank', could be an argument, or matches 'enough' of an option/flag it is a candidate
        * Once we accept an argument as a candidate, we're done looking for candidates as straight arguments are required
        */
-      if (stage->words[w_idx] && (oaptr->flags & (CLI_CMD_OPTIONAL_FLAG|CLI_CMD_OPTIONAL_ARGUMENT)) &&  !strcmp(oaptr->name, stage->words[w_idx])) {
-        candidates[0]=oaptr;
-        num_candidates=1;
+      if (stage->words[w_idx] && (oaptr->flags & (CLI_CMD_OPTIONAL_FLAG | CLI_CMD_OPTIONAL_ARGUMENT)) &&
+          !strcmp(oaptr->name, stage->words[w_idx])) {
+        candidates[0] = oaptr;
+        num_candidates = 1;
         break;
-      } else if (!stage->words[w_idx] || (oaptr->flags & CLI_CMD_ARGUMENT) || !strncasecmp(oaptr->name, stage->words[w_idx], strlen(stage->words[w_idx])) ) {
+      } else if (!stage->words[w_idx] || (oaptr->flags & CLI_CMD_ARGUMENT) ||
+                 !strncasecmp(oaptr->name, stage->words[w_idx], strlen(stage->words[w_idx]))) {
         candidates[num_candidates++] = oaptr;
-      } 
+      }
       if (oaptr->flags & CLI_CMD_ARGUMENT) {
         break;
       }
-
     }
 
     /*
@@ -3019,32 +3018,35 @@ static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage
      * - If we have more than one candidate evaluating for execution punt hard after complaining.
      * - If we have more than one candidate and we're not at end-of-line (
      */
-    if (num_candidates==0) break;
-    if ((num_candidates>1) && ((lastchar=='\0') || (w_idx<(stage->num_words-1)))) {
-      stage->error_word=stage->words[w_idx];
+    if (num_candidates == 0) break;
+    if ((num_candidates > 1) && ((lastchar == '\0') || (w_idx < (stage->num_words - 1)))) {
+      stage->error_word = stage->words[w_idx];
       stage->status = CLI_AMBIGUOUS;
-      cli_error(cli,"Ambiguous option/argument for command %s", stage->command->command);
+      cli_error(cli, "Ambiguous option/argument for command %s", stage->command->command);
       return;
     }
-    
+
     /*
-     * So now we could have one or more candidates.  We need to call get help/completions *only* if this is the 'last-word'
+     * So now we could have one or more candidates.  We need to call get help/completions *only* if this is the
+     * 'last-word'
      * Remember that last word for optinal arguments is last or next to last....
      */
-    if (lastchar!='\0') {
-      int called_comphelp=0;
-      for (c_idx=0;c_idx<num_candidates;c_idx++) {
-        oaptr=candidates[c_idx];
-        
+    if (lastchar != '\0') {
+      int called_comphelp = 0;
+      for (c_idx = 0; c_idx < num_candidates; c_idx++) {
+        oaptr = candidates[c_idx];
+
         // need to know *which* word we're trying to complete for optional_args, hence the difference calls
-        if ( ((oaptr->flags&(CLI_CMD_OPTIONAL_FLAG|CLI_CMD_ARGUMENT)) && (w_idx==(stage->num_words-1))) || 
-             ((oaptr->flags&CLI_CMD_OPTIONAL_ARGUMENT) && (w_idx==(stage->num_words-1))) ) {
-          cli_get_optarg_comphelp(cli, oaptr, comphelp, num_candidates, lastchar, stage->words[w_idx], stage->words[w_idx]);
-          called_comphelp=1;
-        } else if ((oaptr->flags&CLI_CMD_OPTIONAL_ARGUMENT) && (w_idx==(stage->num_words-2)))  {
-          cli_get_optarg_comphelp(cli, oaptr, comphelp, num_candidates, lastchar, stage->words[w_idx], stage->words[w_idx+1]);
-          called_comphelp=1;
-        }  
+        if (((oaptr->flags & (CLI_CMD_OPTIONAL_FLAG | CLI_CMD_ARGUMENT)) && (w_idx == (stage->num_words - 1))) ||
+            ((oaptr->flags & CLI_CMD_OPTIONAL_ARGUMENT) && (w_idx == (stage->num_words - 1)))) {
+          cli_get_optarg_comphelp(cli, oaptr, comphelp, num_candidates, lastchar, stage->words[w_idx],
+                                  stage->words[w_idx]);
+          called_comphelp = 1;
+        } else if ((oaptr->flags & CLI_CMD_OPTIONAL_ARGUMENT) && (w_idx == (stage->num_words - 2))) {
+          cli_get_optarg_comphelp(cli, oaptr, comphelp, num_candidates, lastchar, stage->words[w_idx],
+                                  stage->words[w_idx + 1]);
+          called_comphelp = 1;
+        }
       }
       // if we were 'end-of-word' and looked for completions/help, return to user
       if (called_comphelp) {
@@ -3052,84 +3054,86 @@ static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage
         return;
       }
     }
-    
+
     // set some values for use later - makes code much easier to read
-    if ( ((oaptr->flags & (CLI_CMD_OPTIONAL_FLAG|CLI_CMD_ARGUMENT)) && (w_idx==(stage->num_words-1))) ||
-         ((oaptr->flags & CLI_CMD_OPTIONAL_ARGUMENT) && (w_idx==(stage->num_words-2))) ) {
-      is_last_word=1;
+    if (((oaptr->flags & (CLI_CMD_OPTIONAL_FLAG | CLI_CMD_ARGUMENT)) && (w_idx == (stage->num_words - 1))) ||
+        ((oaptr->flags & CLI_CMD_OPTIONAL_ARGUMENT) && (w_idx == (stage->num_words - 2)))) {
+      is_last_word = 1;
     }
     value = stage->words[w_idx];
     oaptr = candidates[0];
     validator = oaptr->validator;
-    
+
     if ((oaptr->flags & CLI_CMD_OPTIONAL_ARGUMENT)) {
       w_incr = 2;
-      value = stage->words[w_idx+1];
-      if (!value && lastchar=='\0') {
+      value = stage->words[w_idx + 1];
+      if (!value && lastchar == '\0') {
         // hit a optional argument that does not have a value with it
-        cli_error(cli,"Optional argument %s requires a value", stage->words[w_idx]);
-        stage->error_word = stage->words[w_idx];
+        cli_error(cli, "Optional argument %s requires a value", stage->words[w_idx]);
+        stage->error_word = stage->words[w_idx];
         stage->status = CLI_MISSING_VALUE;
-        return ; 
+        return;
       }
     }
 
     /*
-     * Ok, so we're not at end of string and doing help/completions.  
-     * So see if our value is 'valid', to save it, and see if we have any extra processing to 
+     * Ok, so we're not at end of string and doing help/completions.
+     * So see if our value is 'valid', to save it, and see if we have any extra processing to
      * do such as a transient mode check or enter build mode.
      */
-      
-    if (!validator || ((*validator)(cli, oaptr->name, value)==CLI_OK)) {
+
+    if (!validator || ((*validator)(cli, oaptr->name, value) == CLI_OK)) {
       if (oaptr->flags & CLI_CMD_DO_NOT_RECORD) {
         // we want completion and validation, but then leave this 'value' to be seen - used *only* by buildmode
         // as argv[0] with argc=1
         break;
       } else {
         // need to combine remaining words if the CLI_CMD_REMAINDER_OF_LINE flag it set, then we're done processing
-	int set_value_return = 0;
-	
-	if (oaptr->flags & CLI_CMD_REMAINDER_OF_LINE) {
-	  char *combined=NULL;
-	  combined = join_words(stage->num_words-w_idx, stage->words + w_idx);
-	  set_value_return = cli_int_add_optarg_value(cli, oaptr->name, combined, 0);
-	  free_z(combined);
-	} else {
-	  set_value_return = cli_int_add_optarg_value(cli, oaptr->name, value, oaptr->flags&CLI_CMD_OPTION_MULTIPLE);
-	}
+        int set_value_return = 0;
 
-	if (set_value_return != CLI_OK) {
-          cli_error(cli,"%sProblem setting value for command argument %s", lastchar=='\0'?"" : "\n", stage->words[w_idx]);
+        if (oaptr->flags & CLI_CMD_REMAINDER_OF_LINE) {
+          char *combined = NULL;
+          combined = join_words(stage->num_words - w_idx, stage->words + w_idx);
+          set_value_return = cli_int_add_optarg_value(cli, oaptr->name, combined, 0);
+          free_z(combined);
+        } else {
+          set_value_return = cli_int_add_optarg_value(cli, oaptr->name, value, oaptr->flags & CLI_CMD_OPTION_MULTIPLE);
+        }
+
+        if (set_value_return != CLI_OK) {
+          cli_error(cli, "%sProblem setting value for command argument %s", lastchar == '\0' ? "" : "\n",
+                    stage->words[w_idx]);
           cli_reprompt(cli);
-          stage->error_word=stage->words[w_idx];
+          stage->error_word = stage->words[w_idx];
           stage->status = CLI_ERROR;
           return;
         }
-      }      
+      }
     } else {
-      cli_error(cli,"%sProblem parsing command setting %s with value %s", lastchar=='\0'? "": "\n", oaptr->name, stage->words[w_idx]);
+      cli_error(cli, "%sProblem parsing command setting %s with value %s", lastchar == '\0' ? "" : "\n", oaptr->name,
+                stage->words[w_idx]);
       cli_reprompt(cli);
-      stage->error_word=stage->words[w_idx];
+      stage->error_word = stage->words[w_idx];
       stage->status = CLI_ERROR;
       return;
     }
-        
-      
+
     // if this optarg can set the transient mode, then evaluate it if we're not at last word
     if (oaptr->transient_mode && (oaptr->transient_mode(cli, oaptr->name, value))) {
       stage->error_word = stage->words[w_idx];
       stage->status = CLI_ERROR;
-      return  ;
-    }  
-      
-    // only do buildmode optargs if we're a executing a command, parsing command (stage 0), and this is the last word
-    if ( (stage->status==CLI_OK) && (oaptr->flags & CLI_CMD_ALLOW_BUILDMODE) && is_last_word) {
-      stage->status=cli_int_enter_buildmode(cli, stage, value);
-      return ;
+      return;
     }
-      
+
+    // only do buildmode optargs if we're a executing a command, parsing command (stage 0), and this is the last word
+    if ((stage->status == CLI_OK) && (oaptr->flags & CLI_CMD_ALLOW_BUILDMODE) && is_last_word) {
+      stage->status = cli_int_enter_buildmode(cli, stage, value);
+      return;
+    }
+
     /*
-     * Optional flags and arguments can appear multiple times, but true arguments only once.  Advance our optarg starting point
+     * Optional flags and arguments can appear multiple times, but true arguments only once.  Advance our optarg
+     * starting point
      * we see a true argument
      */
     if (oaptr->flags & CLI_CMD_ARGUMENT) {
@@ -3137,25 +3141,22 @@ static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage
       optarg = oaptr->next;
     }
 
-    w_idx+= w_incr;
+    w_idx += w_incr;
     stage->first_unmatched = w_idx;
-  } 
-  
-  
+  }
+
   // Ok, if we're evaluating the command for execution, ensure we have all required arguments.
   if (lastchar == '\0') {
-    for(; optarg; optarg= optarg->next) {
+    for (; optarg; optarg = optarg->next) {
       if (cli->privilege < optarg->privilege) continue;
-      if ((optarg->mode!=cli->mode) && (optarg->mode != cli->transient_mode) && (optarg->mode != MODE_ANY)) continue;
+      if ((optarg->mode != cli->mode) && (optarg->mode != cli->transient_mode) && (optarg->mode != MODE_ANY)) continue;
       if (optarg->flags & CLI_CMD_DO_NOT_RECORD) continue;
       if (optarg->flags & CLI_CMD_ARGUMENT) {
-        cli_error(cli, "Incomplete command, missing required argument '%s'",optarg->name);
-        stage->status=CLI_MISSING_ARGUMENT;
+        cli_error(cli, "Incomplete command, missing required argument '%s'", optarg->name);
+        stage->status = CLI_MISSING_ARGUMENT;
         return;
       }
     }
   }
-  return ;
+  return;
 }
-
-

--- a/libcli.c
+++ b/libcli.c
@@ -663,7 +663,7 @@ void cli_unregister_tree(struct cli_def *cli, struct cli_command *command, int c
   struct cli_command *c, *p = NULL;
 
   if (!command) command = cli->commands;
-
+  
   for (c = command; c;) {
     p = c->next;
     if ((c->command_type == command_type) || (command_type == CLI_ANY_COMMAND)) {
@@ -673,6 +673,11 @@ void cli_unregister_tree(struct cli_def *cli, struct cli_command *command, int c
     }
     c = p;
   }
+}
+
+
+void cli_unregister_all(struct cli_def *cli, struct cli_command *command) {
+  cli_unregister_tree(cli, command, CLI_REGULAR_COMMAND);
 }
 
 int cli_done(struct cli_def *cli) {

--- a/libcli.c
+++ b/libcli.c
@@ -2232,14 +2232,22 @@ char * cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_af
   char *value=NULL;
   struct cli_optarg_pair *optarg_pair;
   
-  for (optarg_pair = cli->found_optargs; optarg_pair; optarg_pair=optarg_pair->next) {
+  printf("cli_get_optarg_value entry - looking for <%s> after <%p>\n", name, (void*)find_after);
+  for (optarg_pair = cli->found_optargs; !value && optarg_pair; optarg_pair=optarg_pair->next) {
+    printf("  Checking %s with value %s <%p> \n", optarg_pair->name, optarg_pair->value, (void*)optarg_pair->value);
+    
+    // check next entry if this isn't our name
     if (strcasecmp(optarg_pair->name, name)) continue;
-    if (find_after && (optarg_pair->value == find_after)) {
+
+    // did we have a find_after, then ignore anything up until our find_after match
+    if ((find_after )&& (optarg_pair->value == find_after)) {
       find_after=NULL;
       continue;
+    } else if ( !find_after) {
+      value = optarg_pair->value;
     }
-    value = optarg_pair->value;
   }
+  printf("cli_get_optarg_value exit - returning <%s><%p>\n", value, value);
   return value;
 }
 

--- a/libcli.h
+++ b/libcli.h
@@ -92,7 +92,11 @@ struct cli_filter {
   struct cli_filter *next;
 };
 
-enum command_types { CLI_REGULAR_COMMAND, CLI_FILTER_COMMAND, CLI_BUILDMODE_COMMAND };
+enum command_types {
+  CLI_REGULAR_COMMAND,
+  CLI_FILTER_COMMAND,
+  CLI_BUILDMODE_COMMAND
+};
 
 struct cli_command {
   char *command;
@@ -106,10 +110,9 @@ struct cli_command {
   struct cli_command *parent;
   struct cli_optarg *optargs;
   int (*filter)(struct cli_def *cli, const char *string, void *data);
-  int (*init) (struct cli_def *cli, int, char **, struct cli_filter *filt);
+  int (*init)(struct cli_def *cli, int, char **, struct cli_filter *filt);
   int command_type;
 };
-
 
 struct cli_comphelp {
   int comma_separated;
@@ -117,17 +120,17 @@ struct cli_comphelp {
   int num_entries;
 };
 
-enum optarg_flags {     CLI_CMD_OPTIONAL_FLAG     = 1 << 0,
-			            CLI_CMD_OPTIONAL_ARGUMENT = 1 << 1,
-                        CLI_CMD_ARGUMENT          = 1 << 2,
-                        CLI_CMD_ALLOW_BUILDMODE   = 1 << 3,
-                        CLI_CMD_OPTION_MULTIPLE   = 1 << 4,
-                        CLI_CMD_OPTION_SEEN       = 1 << 5,
-                        CLI_CMD_TRANSIENT_MODE    = 1 << 6,
-			CLI_CMD_DO_NOT_RECORD     = 1 << 7,
-			CLI_CMD_REMAINDER_OF_LINE = 1 << 8,
-                };
-                
+enum optarg_flags {
+  CLI_CMD_OPTIONAL_FLAG = 1 << 0,
+  CLI_CMD_OPTIONAL_ARGUMENT = 1 << 1,
+  CLI_CMD_ARGUMENT = 1 << 2,
+  CLI_CMD_ALLOW_BUILDMODE = 1 << 3,
+  CLI_CMD_OPTION_MULTIPLE = 1 << 4,
+  CLI_CMD_OPTION_SEEN = 1 << 5,
+  CLI_CMD_TRANSIENT_MODE = 1 << 6,
+  CLI_CMD_DO_NOT_RECORD = 1 << 7,
+  CLI_CMD_REMAINDER_OF_LINE = 1 << 8,
+};
 
 struct cli_optarg {
   char *name;
@@ -164,7 +167,7 @@ struct cli_pipeline {
   char *cmdline;
   char *words[CLI_MAX_LINE_WORDS];
   int num_words;
-  int num_stages;  
+  int num_stages;
   struct cli_pipeline_stage stage[CLI_MAX_LINE_WORDS];
 };
 
@@ -175,7 +178,7 @@ struct cli_buildmode {
   char *cname;
   int mode;
   int transient_mode;
-  char * mode_text;
+  char *mode_text;
 };
 
 struct cli_def *cli_init();
@@ -222,20 +225,21 @@ void cli_free_comphelp(struct cli_comphelp *comphelp);
 int cli_add_comphelp_entry(struct cli_comphelp *comphelp, const char *entry);
 void cli_set_transient_mode(struct cli_def *cli, int transient_mode);
 struct cli_command *cli_register_filter(struct cli_def *cli, const char *command,
-                                         int(*init) (struct cli_def *cli, int, char **, struct cli_filter *filt),
-                                         int(*filter)(struct cli_def *, const char *, void *),
-                                         int privilege, int mode, const char *help);
+                                        int (*init)(struct cli_def *cli, int, char **, struct cli_filter *filt),
+                                        int (*filter)(struct cli_def *, const char *, void *), int privilege, int mode,
+                                        const char *help);
 int cli_unregister_filter(struct cli_def *cli, const char *command);
-int cli_register_optarg(struct cli_command *cmd, const char *name, int flags, int priviledge, int mode, const char *help, 
-                                        int (*get_completions)(struct cli_def *cli, const char*, const char *, struct cli_comphelp * ),
-                                        int (*validator)(struct cli_def *cli, const char *, const char *),
-                                        int (*transient_mode)(struct cli_def *, const char *, const char *));
-char *cli_find_optarg_value(struct cli_def *cli, char *name, char *find_after) ;
-struct cli_optarg_pair  *cli_get_all_found_optargs(struct cli_def *cli);
+int cli_register_optarg(struct cli_command *cmd, const char *name, int flags, int priviledge, int mode,
+                        const char *help,
+                        int (*get_completions)(struct cli_def *cli, const char *, const char *, struct cli_comphelp *),
+                        int (*validator)(struct cli_def *cli, const char *, const char *),
+                        int (*transient_mode)(struct cli_def *, const char *, const char *));
+char *cli_find_optarg_value(struct cli_def *cli, char *name, char *find_after);
+struct cli_optarg_pair *cli_get_all_found_optargs(struct cli_def *cli);
 int cli_unregister_optarg(struct cli_command *cmd, const char *name);
-char * cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_after);
+char *cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_after);
 void cli_unregister_all(struct cli_def *cli, struct cli_command *command);
-void cli_unregister_all_optarg(struct cli_optarg *optarg) ;
+void cli_unregister_all_optarg(struct cli_optarg *optarg);
 
 #ifdef __cplusplus
 }

--- a/libcli.h
+++ b/libcli.h
@@ -132,6 +132,7 @@ enum optarg_flags {
   CLI_CMD_DO_NOT_RECORD = 1 << 7,
   CLI_CMD_REMAINDER_OF_LINE = 1 << 8,
   CLI_CMD_HYPHENATED_OPTION = 1 << 9,
+  CLI_CMD_SPOT_CHECK = 1 << 10,
 };
 
 struct cli_optarg {

--- a/libcli.h
+++ b/libcli.h
@@ -12,14 +12,23 @@ extern "C" {
 #include <sys/time.h>
 
 #define LIBCLI_VERSION_MAJOR 1
-#define LIBCLI_VERISON_MINOR 9
-#define LIBCLI_VERISON_REVISION 8
+#define LIBCLI_VERISON_MINOR 10
+#define LIBCLI_VERISON_REVISION 0
 #define LIBCLI_VERSION ((LIBCLI_VERSION_MAJOR << 16) | (LIBCLI_VERSION_MINOR << 8) | LIBCLI_VERSION_REVISION)
 
 #define CLI_OK 0
 #define CLI_ERROR -1
 #define CLI_QUIT -2
 #define CLI_ERROR_ARG -3
+#define CLI_AMBIGUOUS -4
+#define CLI_UNRECOGNIZED -5
+#define CLI_MISSING_ARGUMENT -6
+#define CLI_MISSING_VALUE -7
+#define CLI_BUILDMODE_COMMAND_START -8
+#define CLI_BUILDMODE_COMMAND_ERROR -9
+#define CLI_BUILDMODE_COMMAND_EXTEND -10
+#define CLI_BUILDMODE_COMMAND_CANCEL -11
+#define CLI_BUILDMODE_COMMAND_EXIT -12
 
 #define MAX_HISTORY 256
 
@@ -70,6 +79,11 @@ struct cli_def {
   time_t last_action;
   int telnet_protocol;
   void *user_context;
+  struct cli_command *filter_commands;
+  struct cli_optarg_pair *found_optargs;
+  int transient_mode;
+  struct cli_pipeline *pipeline;
+  struct cli_buildmode *buildmode;
 };
 
 struct cli_filter {
@@ -77,6 +91,8 @@ struct cli_filter {
   void *data;
   struct cli_filter *next;
 };
+
+enum command_types { CLI_REGULAR_COMMAND, CLI_FILTER_COMMAND, CLI_BUILDMODE_COMMAND };
 
 struct cli_command {
   char *command;
@@ -88,6 +104,77 @@ struct cli_command {
   struct cli_command *next;
   struct cli_command *children;
   struct cli_command *parent;
+  struct cli_optarg *optargs;
+  int (*filter)(struct cli_def *cli, const char *string, void *data);
+  int (*init) (struct cli_def *cli, int, char **, struct cli_filter *filt);
+  int command_type;
+};
+
+
+struct cli_comphelp {
+  int comma_separated;
+  char **entries;
+  int num_entries;
+};
+
+enum optarg_flags {     CLI_CMD_OPTIONAL_FLAG     = 1 << 0,
+			            CLI_CMD_OPTIONAL_ARGUMENT = 1 << 1,
+                        CLI_CMD_ARGUMENT          = 1 << 2,
+                        CLI_CMD_ALLOW_BUILDMODE   = 1 << 3,
+                        CLI_CMD_OPTION_MULTIPLE   = 1 << 4,
+                        CLI_CMD_OPTION_SEEN       = 1 << 5,
+                        CLI_CMD_TRANSIENT_MODE    = 1 << 6,
+			CLI_CMD_DO_NOT_RECORD     = 1 << 7,
+                };
+                
+
+struct cli_optarg {
+  char *name;
+  int flags;
+  char *help;
+  int mode;
+  int privilege;
+  unsigned int unique_len;
+  int (*get_completions)(struct cli_def *, const char *, const char *, struct cli_comphelp *);
+  int (*validator)(struct cli_def *, const char *, const char *);
+  int (*transient_mode)(struct cli_def *, const char *, const char *);
+  struct cli_optarg *next;
+};
+
+struct cli_optarg_pair {
+  char *name;
+  char *value;
+  struct cli_optarg_pair *next;
+};
+
+struct cli_pipeline_stage {
+  struct cli_command *command;
+  struct cli_optarg_pair *found_optargs;
+  char **words;
+  int num_words;
+  int status;
+  int first_unmatched;
+  int first_optarg;
+  int stage_num;
+  char *error_word;
+};
+
+struct cli_pipeline {
+  char *cmdline;
+  char *words[CLI_MAX_LINE_WORDS];
+  int num_words;
+  int num_stages;  
+  struct cli_pipeline_stage stage[CLI_MAX_LINE_WORDS];
+};
+
+struct cli_buildmode {
+  struct cli_command *c;
+  struct cli_command *commands;
+  struct cli_optarg_pair *found_optargs;
+  char *cname;
+  int mode;
+  int transient_mode;
+  char * mode_text;
 };
 
 struct cli_def *cli_init();
@@ -129,6 +216,25 @@ void cli_telnet_protocol(struct cli_def *cli, int telnet_protocol);
 // Set/get user context
 void cli_set_context(struct cli_def *cli, void *context);
 void *cli_get_context(struct cli_def *cli);
+
+void cli_free_comphelp(struct cli_comphelp *comphelp);
+int cli_add_comphelp_entry(struct cli_comphelp *comphelp, const char *entry);
+void cli_set_transient_mode(struct cli_def *cli, int transient_mode);
+struct cli_command *cli_register_filter(struct cli_def *cli, const char *command,
+                                         int(*init) (struct cli_def *cli, int, char **, struct cli_filter *filt),
+                                         int(*filter)(struct cli_def *, const char *, void *),
+                                         int privilege, int mode, const char *help);
+int cli_unregister_filter(struct cli_def *cli, const char *command);
+int cli_register_optarg(struct cli_command *cmd, const char *name, int flags, int priviledge, int mode, const char *help, 
+                                        int (*get_completions)(struct cli_def *cli, const char*, const char *, struct cli_comphelp * ),
+                                        int (*validator)(struct cli_def *cli, const char *, const char *),
+                                        int (*transient_mode)(struct cli_def *, const char *, const char *));
+char *cli_find_optarg_value(struct cli_def *cli, char *name, char *find_after) ;
+struct cli_optarg_pair  *cli_get_all_found_optargs(struct cli_def *cli);
+int cli_unregister_optarg(struct cli_command *cmd, const char *name);
+char * cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_after);
+void cli_unregister_all(struct cli_def *cli, struct cli_command *command);
+void cli_unregister_all_optarg(struct cli_optarg *optarg) ;
 
 #ifdef __cplusplus
 }

--- a/libcli.h
+++ b/libcli.h
@@ -105,6 +105,7 @@ struct cli_command {
   char *help;
   int privilege;
   int mode;
+  struct cli_command *previous;
   struct cli_command *next;
   struct cli_command *children;
   struct cli_command *parent;
@@ -239,8 +240,9 @@ char *cli_find_optarg_value(struct cli_def *cli, char *name, char *find_after);
 struct cli_optarg_pair *cli_get_all_found_optargs(struct cli_def *cli);
 int cli_unregister_optarg(struct cli_command *cmd, const char *name);
 char *cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_after);
-void cli_unregister_all(struct cli_def *cli, struct cli_command *command);
 void cli_unregister_all_optarg(struct cli_command *c);
+void cli_unregister_all_filters(struct cli_def *cli);
+void cli_unregister_all_commands(struct cli_def *cli);
 
 #ifdef __cplusplus
 }

--- a/libcli.h
+++ b/libcli.h
@@ -95,7 +95,7 @@ enum command_types {
   CLI_ANY_COMMAND,
   CLI_REGULAR_COMMAND,
   CLI_FILTER_COMMAND,
-  CLI_BUILDMODE_COMMAND
+  CLI_BUILDMODE_COMMAND,
 };
 
 struct cli_command {

--- a/libcli.h
+++ b/libcli.h
@@ -130,6 +130,7 @@ enum optarg_flags {
   CLI_CMD_TRANSIENT_MODE = 1 << 6,
   CLI_CMD_DO_NOT_RECORD = 1 << 7,
   CLI_CMD_REMAINDER_OF_LINE = 1 << 8,
+  CLI_CMD_HYPHENATED_OPTION = 1 << 9,
 };
 
 struct cli_optarg {
@@ -169,6 +170,7 @@ struct cli_pipeline {
   int num_words;
   int num_stages;
   struct cli_pipeline_stage stage[CLI_MAX_LINE_WORDS];
+  struct cli_pipeline_stage *current_stage;
 };
 
 struct cli_buildmode {

--- a/libcli.h
+++ b/libcli.h
@@ -125,6 +125,7 @@ enum optarg_flags {     CLI_CMD_OPTIONAL_FLAG     = 1 << 0,
                         CLI_CMD_OPTION_SEEN       = 1 << 5,
                         CLI_CMD_TRANSIENT_MODE    = 1 << 6,
 			CLI_CMD_DO_NOT_RECORD     = 1 << 7,
+			CLI_CMD_REMAINDER_OF_LINE = 1 << 8,
                 };
                 
 

--- a/libcli.h
+++ b/libcli.h
@@ -243,6 +243,7 @@ char *cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_aft
 void cli_unregister_all_optarg(struct cli_command *c);
 void cli_unregister_all_filters(struct cli_def *cli);
 void cli_unregister_all_commands(struct cli_def *cli);
+void cli_unregister_all(struct cli_def *cli, struct cli_command *command) ;
 
 #ifdef __cplusplus
 }

--- a/libcli.h
+++ b/libcli.h
@@ -243,7 +243,7 @@ char *cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_aft
 void cli_unregister_all_optarg(struct cli_command *c);
 void cli_unregister_all_filters(struct cli_def *cli);
 void cli_unregister_all_commands(struct cli_def *cli);
-void cli_unregister_all(struct cli_def *cli, struct cli_command *command) ;
+void cli_unregister_all(struct cli_def *cli, struct cli_command *command);
 
 #ifdef __cplusplus
 }

--- a/libcli.h
+++ b/libcli.h
@@ -24,11 +24,11 @@ extern "C" {
 #define CLI_UNRECOGNIZED -5
 #define CLI_MISSING_ARGUMENT -6
 #define CLI_MISSING_VALUE -7
-#define CLI_BUILDMODE_COMMAND_START -8
-#define CLI_BUILDMODE_COMMAND_ERROR -9
-#define CLI_BUILDMODE_COMMAND_EXTEND -10
-#define CLI_BUILDMODE_COMMAND_CANCEL -11
-#define CLI_BUILDMODE_COMMAND_EXIT -12
+#define CLI_BUILDMODE_START -8
+#define CLI_BUILDMODE_ERROR -9
+#define CLI_BUILDMODE_EXTEND -10
+#define CLI_BUILDMODE_CANCEL -11
+#define CLI_BUILDMODE_EXIT -12
 
 #define MAX_HISTORY 256
 
@@ -79,7 +79,6 @@ struct cli_def {
   time_t last_action;
   int telnet_protocol;
   void *user_context;
-  struct cli_command *filter_commands;
   struct cli_optarg_pair *found_optargs;
   int transient_mode;
   struct cli_pipeline *pipeline;
@@ -93,6 +92,7 @@ struct cli_filter {
 };
 
 enum command_types {
+  CLI_ANY_COMMAND,
   CLI_REGULAR_COMMAND,
   CLI_FILTER_COMMAND,
   CLI_BUILDMODE_COMMAND
@@ -174,8 +174,7 @@ struct cli_pipeline {
 };
 
 struct cli_buildmode {
-  struct cli_command *c;
-  struct cli_command *commands;
+  struct cli_command *command;
   struct cli_optarg_pair *found_optargs;
   char *cname;
   int mode;
@@ -241,7 +240,7 @@ struct cli_optarg_pair *cli_get_all_found_optargs(struct cli_def *cli);
 int cli_unregister_optarg(struct cli_command *cmd, const char *name);
 char *cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_after);
 void cli_unregister_all(struct cli_def *cli, struct cli_command *command);
-void cli_unregister_all_optarg(struct cli_optarg *optarg);
+void cli_unregister_all_optarg(struct cli_command *c);
 
 #ifdef __cplusplus
 }

--- a/libcli.spec
+++ b/libcli.spec
@@ -1,7 +1,7 @@
-Version: 1.9.8
+Version: 1.10.0
 Summary: Cisco-like telnet command-line library
 Name: libcli
-Release: 4
+Release: 1
 License: LGPL
 Group: Library/Communication
 Source: %{name}-%{version}.tar.gz
@@ -67,6 +67,19 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 
 %changelog
+* Mon Jul 16 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.0-1
+- Add support for named arguments, optional flags, and optional arguments
+- Support help and tab complete for options/arguments
+- Enable users to add custom 'filters', including support for options/arguments
+- Replaced current interal filters with equivalent 'user filters'
+- Added examples of options/arguments to clitest
+- Added support for 'building' longer commands one option/argument at a time (buildmode)
+- Additional minor Coverity/valgrind related fixes
+- Tab completion will show up until an ambiguity, or entire entry if only one found
+- Tab completion for options/arguments will show '[]' around optional items
+- Tab completion for options/arguments will show '<>' around required items
+- Restructured clitest.c so 'cli_init()' is done in child thread
+
 * Wed Sep 19 2018 Rob Sanders <rsanders@forcepoint.com> 1.9.8-4
 - Update spac file to use relative links for libcli.so symlinks 
 


### PR DESCRIPTION
Add new cli_optarg type 'CLI_CMD_SPOT_CHECK'.  This opt arg is placed in the evaluating chain immediately before a 'decision' point, and can be used to ensure that any required optargs have been seen/specified before proceeding with command execution.  Note that the actual command callback is never called in this case.
The clitest.c program has been tweaked to uses this.  The test case is that at least one of the optinal arguments 'transparent' and 'color' needs to be set, but you cannot have both transparent and a color of 'black'.
Also added 'show' and 'unset' to reserved words when generating a 'buildmode' environment, and a few tweaks to documentation.