### PR TITLE
Optarg updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ install: $(TARGET_LIBS)
 rpmprep:
 	rm -rf libcli-$(MAJOR).$(MINOR).$(REVISION)
 	mkdir libcli-$(MAJOR).$(MINOR).$(REVISION)
-	cp -R libcli.{c,h} libcli.spec clitest.c Makefile COPYING README libcli-$(MAJOR).$(MINOR).$(REVISION)
+	cp -R libcli.{c,h} libcli.spec clitest.c Makefile COPYING README.md doc libcli-$(MAJOR).$(MINOR).$(REVISION)
 	tar zcvf libcli-$(MAJOR).$(MINOR).$(REVISION).tar.gz --exclude CVS --exclude *.tar.gz libcli-$(MAJOR).$(MINOR).$(REVISION)
 	rm -rf libcli-$(MAJOR).$(MINOR).$(REVISION)
 

--- a/clitest.c
+++ b/clitest.c
@@ -254,9 +254,11 @@ int shape_transient_eval(struct cli_def *cli, const char *name, const char *valu
   printf("shape_transient_eval called with <%s>\n", value);
   if (!strcmp(value, "rectangle")) {
     cli_set_transient_mode(cli, MODE_POLYGON_RECTANGLE);
+    cli_set_optarg_value(cli, "duplicateShapeValue", value, 0);
     return CLI_OK;
   } else if (!strcmp(value, "triangle")) {
     cli_set_transient_mode(cli, MODE_POLYGON_TRIANGLE);
+    cli_set_optarg_value(cli, "duplicateShapeValue", value, 0);
     return CLI_OK;
   }
   cli_error(cli, "unrecognized value for setting %s -> %s", name, value);

--- a/libcli.c
+++ b/libcli.c
@@ -141,7 +141,6 @@ static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage
 static int cli_int_enter_buildmode(struct cli_def *cli, struct cli_pipeline_stage *stage, char *mode_text);
 static char *cli_int_buildmode_extend_cmdline(char *, char *word);
 static void cli_int_free_buildmode(struct cli_def *cli);
-static int cli_int_add_optarg_value(struct cli_def *cli, const char *name, const char *value, int allow_multiple);
 static void cli_free_command(struct cli_def *cli, struct cli_command *cmd);
 static int cli_int_unregister_command_core(struct cli_def *cli, const char *command, int command_type);
 static int cli_int_unregister_buildmode_command(struct cli_def *cli, const char *command) __attribute__((unused));
@@ -2183,7 +2182,7 @@ void cli_int_unset_optarg_value(struct cli_def *cli, const char *name) {
   }
 }
 
-int cli_int_add_optarg_value(struct cli_def *cli, const char *name, const char *value, int allow_multiple) {
+int cli_set_optarg_value(struct cli_def *cli, const char *name, const char *value, int allow_multiple) {
   struct cli_optarg_pair *optarg_pair, **anchor;
   int rc = CLI_ERROR;
 
@@ -2452,7 +2451,7 @@ int cli_int_buildmode_flag_cback(struct cli_def *cli, const char *command, char 
     cli_error(cli, "Extra arguments on command line, command ignored.");
     rc = CLI_ERROR;
   }
-  if (cli_int_add_optarg_value(cli, command, command, 0)) {
+  if (cli_set_optarg_value(cli, command, command, 0)) {
     cli_error(cli, "Problem setting value for optional flag %s", command);
     rc = CLI_ERROR;
   }
@@ -2467,7 +2466,7 @@ int cli_int_buildmode_flag_multiple_cback(struct cli_def *cli, const char *comma
     cli_error(cli, "Extra arguments on command line, command ignored.");
     rc = CLI_ERROR;
   }
-  if (cli_int_add_optarg_value(cli, command, command, CLI_CMD_OPTION_MULTIPLE)) {
+  if (cli_set_optarg_value(cli, command, command, CLI_CMD_OPTION_MULTIPLE)) {
     cli_error(cli, "Problem setting value for optional flag %s", command);
     rc = CLI_ERROR;
   }
@@ -3066,10 +3065,10 @@ static void cli_int_parse_optargs(struct cli_def *cli, struct cli_pipeline_stage
         if (oaptr->flags & CLI_CMD_REMAINDER_OF_LINE) {
           char *combined = NULL;
           combined = join_words(stage->num_words - word_idx, stage->words + word_idx);
-          set_value_return = cli_int_add_optarg_value(cli, oaptr->name, combined, 0);
+          set_value_return = cli_set_optarg_value(cli, oaptr->name, combined, 0);
           free_z(combined);
         } else {
-          set_value_return = cli_int_add_optarg_value(cli, oaptr->name, value, oaptr->flags & CLI_CMD_OPTION_MULTIPLE);
+          set_value_return = cli_set_optarg_value(cli, oaptr->name, value, oaptr->flags & CLI_CMD_OPTION_MULTIPLE);
         }
 
         if (set_value_return != CLI_OK) {

--- a/libcli.c
+++ b/libcli.c
@@ -2841,7 +2841,8 @@ static void cli_get_optarg_comphelp(struct cli_def *cli, struct cli_optarg *opta
   char *allow_buildmode = BUILDMODE_NO;
   int (*get_completions)(struct cli_def *, const char *, const char *, struct cli_comphelp *) = NULL;
   char *tptr = NULL;
-
+  char *tname = NULL;
+  
   // If we've already seen a value by this exact name, skip it, unless the multiple flag is set
   if (cli_find_optarg_value(cli, optarg->name, NULL) && !(optarg->flags & (CLI_CMD_OPTION_MULTIPLE))) return;
 
@@ -2884,16 +2885,17 @@ static void cli_get_optarg_comphelp(struct cli_def *cli, struct cli_optarg *opta
   }
 
   // Fill in with help text or completor value(s) as indicated
-  if (lastchar == '?' && asprintf(&tptr, "%s%s%s", delim_start, optarg->name, delim_end) != -1) {
+  if (lastchar == '?' && asprintf(&tname, "%s%s%s", delim_start, optarg->name, delim_end) != -1) {
     if (optarg->flags & CLI_CMD_ALLOW_BUILDMODE) allow_buildmode = BUILDMODE_YES;
-    if (help_insert && (asprintf(&tptr, "  %-20s enter '%s' to %s%s", tptr, optarg->name,
+    if (help_insert && (asprintf(&tptr, "  %-20s enter '%s' to %s%s", tname, optarg->name,
                                  (optarg->help) ? optarg->help : "", allow_buildmode) != -1)) {
       cli_add_comphelp_entry(comphelp, tptr);
       free_z(tptr);
-    } else if (asprintf(&tptr, "  %-20s %s%s", tptr, (optarg->help) ? optarg->help : "", allow_buildmode) != -1) {
+    } else if (asprintf(&tptr, "  %-20s %s%s", tname, (optarg->help) ? optarg->help : "", allow_buildmode) != -1) {
       cli_add_comphelp_entry(comphelp, tptr);
       free_z(tptr);
     }
+    free_z(tname);
   } else if (lastchar == CTRL('I')) {
     if (get_completions) {
       (*get_completions)(cli, optarg->name, next_word, comphelp);

--- a/libcli.h
+++ b/libcli.h
@@ -241,6 +241,7 @@ char *cli_find_optarg_value(struct cli_def *cli, char *name, char *find_after);
 struct cli_optarg_pair *cli_get_all_found_optargs(struct cli_def *cli);
 int cli_unregister_optarg(struct cli_command *cmd, const char *name);
 char *cli_get_optarg_value(struct cli_def *cli, const char *name, char *find_after);
+int cli_set_optarg_value(struct cli_def *cli, const char *name, const char *value, int allow_multiple);
 void cli_unregister_all_optarg(struct cli_command *c);
 void cli_unregister_all_filters(struct cli_def *cli);
 void cli_unregister_all_commands(struct cli_def *cli);

--- a/libcli.spec
+++ b/libcli.spec
@@ -1,7 +1,7 @@
 Version: 1.10.0
 Summary: Cisco-like telnet command-line library
 Name: libcli
-Release: 1
+Release: 2
 License: LGPL
 Group: Library/Communication
 Source: %{name}-%{version}.tar.gz
@@ -67,6 +67,11 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 
 %changelog
+* Tue Jul 23 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.0-2
+- Fix spec file and rpm build issues
+- Fix 2 memory leaks (tab completion and help formatting)
+- Expose cli_set_optarg_value() for external use
+
 * Tue Jul 16 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.0-1
 - Add support for named arguments, optional flags, and optional arguments
 - Support help and tab complete for options/arguments

--- a/libcli.spec
+++ b/libcli.spec
@@ -60,14 +60,14 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 
 %files devel
-%doc README
+%doc README.md doc/developers-guide.md
 %{_libdir}/*.so*
 %{_libdir}/*.a
 %{_includedir}/*.h
 %defattr(-, root, root)
 
 %changelog
-* Mon Jul 16 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.0-1
+* Tue Jul 16 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.0-1
 - Add support for named arguments, optional flags, and optional arguments
 - Support help and tab complete for options/arguments
 - Enable users to add custom 'filters', including support for options/arguments


### PR DESCRIPTION
Fixed Makefile & libcli.spec to build rpms again (and pick up doc/developers-guide.md for /usr/share/doc/libcli-devel....)
Fixed 2 memory leaks (one for tab completion, one for help)
Renamed/exposed cli_int_add_set_optarg_value() as cli_set_optarg_value()
bumped release from 1.10.0-1 to 1.10.0-2
