### PR TITLE
Patch against libcli 1 10 0 rel2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PREFIX = /usr/local
 
 MAJOR = 1
 MINOR = 10
-REVISION = 0
+REVISION = 1
 LIB = libcli.so
 LIB_STATIC = libcli.a
 

--- a/clitest.c
+++ b/clitest.c
@@ -184,16 +184,15 @@ int cmd_perimeter(struct cli_def *cli, const char *command, char *argv[], int ar
   int i = 1, numSides = 0;
   int perimeter = 0;
   int verbose_count = 0;
-  char *verboseArg = NULL;
+  char *verboseArg;
   char *shapeName = NULL;
 
   cli_print(cli, "perimeter callback, with %d args", argc);
   for (; optargs; optargs = optargs->next) cli_print(cli, "%d, %s=%s", i++, optargs->name, optargs->value);
 
-  if ((verboseArg = cli_get_optarg_value(cli, "verbose", verboseArg))) {
-    do {
-      verbose_count++;
-    } while ((verboseArg = cli_get_optarg_value(cli, "verbose", verboseArg)));
+  verboseArg = NULL;
+  while ((verboseArg = cli_get_optarg_value(cli, "verbose", verboseArg))) {
+    verbose_count++;
   }
   cli_print(cli, "verbose argument was seen  %d times", verbose_count);
 

--- a/clitest.c
+++ b/clitest.c
@@ -366,17 +366,17 @@ void run_child(int x) {
   // Register some commands/subcommands to demonstrate opt/arg and buildmode operations
 
   c = cli_register_command(cli, NULL, "perimeter", cmd_perimeter, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
-                           "Calculate perimeter of polygon");
+                           "Calculate perimeter of polygon\nhas embedded newline\nand_a_really_long_line_that_is_much_longer_than_80_columns_to_show_that_wrap_case");
   cli_register_optarg(c, "transparent", CLI_CMD_OPTIONAL_FLAG, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
                       "Set transparent flag", NULL, NULL, NULL);
   cli_register_optarg(c, "verbose", CLI_CMD_OPTIONAL_FLAG | CLI_CMD_OPTION_MULTIPLE, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
-                      "Set transparent flag", NULL, NULL, NULL);
+                      "Set verbose flagwith some humongously long string \nwithout any embedded newlines in it to test with", NULL, NULL, NULL);
   cli_register_optarg(c, "color", CLI_CMD_OPTIONAL_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, "Set color",
                       color_completor, color_validator, NULL);
   cli_register_optarg(c, "__check1__", CLI_CMD_SPOT_CHECK, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL, NULL,
                       check1_validator, NULL);
   cli_register_optarg(c, "shape", CLI_CMD_ARGUMENT | CLI_CMD_ALLOW_BUILDMODE, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
-                      "Specify shape to calclate perimeter for", shape_completor, shape_validator,
+                      "Specify shape(shows subtext on help)\ttriangle\tSpecify a triangle\trectangle\tspecify a rectangle", shape_completor, shape_validator,
                       shape_transient_eval);
   cli_register_optarg(c, "side_1", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_TRIANGLE,
                       "Specify side 1 length", NULL, side_length_validator, NULL);

--- a/libcli.c
+++ b/libcli.c
@@ -2276,7 +2276,7 @@ int cli_int_enter_buildmode(struct cli_def *cli, struct cli_pipeline_stage *stag
   // Build new *limited* list of commands from this commands optargs
   for (optarg = stage->command->optargs; optarg; optarg = optarg->next) {
     // Don't allow anything that could redefine our mode or buildmode mode, or redefine exit/cancel/show/unset
-    if (!strcmp(optarg->name, "cancel") || !strcmp(optarg->name, "exit") || !strcmp(optarg->name, "show") ||
+    if (!strcmp(optarg->name, "cancel") || !strcmp(optarg->name, "execute") || !strcmp(optarg->name, "show") ||
         !strcmp(optarg->name, "unset")) {
       cli_error(cli, "Default buildmode command conflicts with optarg named %s", optarg->name);
       rc = CLI_BUILDMODE_ERROR;
@@ -2315,8 +2315,8 @@ int cli_int_enter_buildmode(struct cli_def *cli, struct cli_pipeline_stage *stag
   // And lastly four 'always there' commands to cancel current mode and to execute the command, show settings, and unset
   cli_int_register_buildmode_command(cli, NULL, "cancel", cli_int_buildmode_cancel_cback, PRIVILEGE_UNPRIVILEGED,
                                      cli->mode, "Cancel command");
-  cli_int_register_buildmode_command(cli, NULL, "exit", cli_int_buildmode_exit_cback, PRIVILEGE_UNPRIVILEGED, cli->mode,
-                                     "Exit and execute command");
+  cli_int_register_buildmode_command(cli, NULL, "execute", cli_int_buildmode_exit_cback, PRIVILEGE_UNPRIVILEGED, cli->mode,
+                                     "Execute command");
   cli_int_register_buildmode_command(cli, NULL, "show", cli_int_buildmode_show_cback, PRIVILEGE_UNPRIVILEGED, cli->mode,
                                      "Show current settings");
   c = cli_int_register_buildmode_command(cli, NULL, "unset", cli_int_buildmode_unset_cback, PRIVILEGE_UNPRIVILEGED,

--- a/libcli.c
+++ b/libcli.c
@@ -166,7 +166,7 @@ static int cli_int_execute_pipeline(struct cli_def *cli, struct cli_pipeline *pi
 inline void cli_int_show_pipeline(struct cli_def *cli, struct cli_pipeline *pipeline);
 static void cli_int_free_pipeline(struct cli_pipeline *pipeline);
 static void cli_register_command_core(struct cli_def *cli, struct cli_command *parent, struct cli_command *c);
-static void cli_int_wrap_help_line (char *nameptr, char *helpptr, struct cli_comphelp *comphelp) ;
+static void cli_int_wrap_help_line(char *nameptr, char *helpptr, struct cli_comphelp *comphelp);
 
 static ssize_t _write(int fd, const void *buf, size_t count) {
   size_t written = 0;
@@ -862,9 +862,8 @@ void cli_get_completions(struct cli_def *cli, const char *command, char lastchar
     }
 
     if (lastchar == '?') {
-      
       if (asprintf(&strptr, "  %-20s ", c->command) != -1) {
-        cli_int_wrap_help_line (strptr, c->help, comphelp);
+        cli_int_wrap_help_line(strptr, c->help, comphelp);
         free_z(strptr);
       }
     } else {
@@ -2836,7 +2835,7 @@ int cli_int_execute_pipeline(struct cli_def *cli, struct cli_pipeline *pipeline)
  *  Attemp quick dirty wrapping of helptext taking into account the offset from name, embedded
  *  cr/lf in helptext, and trying to split on last white-text before the margin
  */
-void cli_int_wrap_help_line (char *nameptr, char *helpptr, struct cli_comphelp *comphelp) {
+void cli_int_wrap_help_line(char *nameptr, char *helpptr, struct cli_comphelp *comphelp) {
   int maxwidth = 80;  // temporary assumption, to be fixed later when libcli 'understands' screen dimensions
   int availwidth;
   int namewidth;
@@ -2859,7 +2858,7 @@ void cli_int_wrap_help_line (char *nameptr, char *helpptr, struct cli_comphelp *
     if (toprint > availwidth) {
       toprint = availwidth;
       while ((toprint>=0) && !isspace(helpptr[toprint])) toprint--;
-      if ( toprint < 0) {
+      if (toprint < 0) {
         // if we backed up and found no whitespace, dump as much as we can
 	toprint = availwidth;
       }
@@ -2867,17 +2866,16 @@ void cli_int_wrap_help_line (char *nameptr, char *helpptr, struct cli_comphelp *
     if ( (crlf = strpbrk(helpptr,"\n\r"))) {
       // crlf is a pointer - see if it is 'before' the toprint index
       if ((crlf-helpptr) < toprint) {
-        // ok, crlf is before the wrap, us it
+        // ok, crlf is before the wrap, so have line break here.
         toprint = (crlf-helpptr);
       }
     }
     
     if (asprintf(&line, "%*.*s%.*s", namewidth, namewidth, nameptr, toprint, helpptr) < 0) break;
     cli_add_comphelp_entry(comphelp, line);
-    if (nameptr != emptystring) {
-      nameptr = emptystring;
-    }
     free_z(line);
+
+    nameptr = emptystring;
     helpptr += toprint;
     // advance to first non whitespace
     while (helpptr && isspace(*helpptr)) helpptr++;
@@ -3003,7 +3001,7 @@ static void cli_get_optarg_comphelp(struct cli_def *cli, struct cli_optarg *opta
       // we may not need to show all off the 'extra help', so loop here
       do {
         nameptr = strtok_r(NULL, "\t", &saveptr);
-	helpptr = strtok_r(NULL, "\t", &saveptr);
+        helpptr = strtok_r(NULL, "\t", &saveptr);
       } while (working && nameptr && helpptr && (anchor_word && (strncmp(anchor_word, nameptr, strlen(anchor_word)))));
     } while (working && nameptr && helpptr);
     free_z(working);

--- a/libcli.c
+++ b/libcli.c
@@ -500,7 +500,7 @@ int cli_show_help(struct cli_def *cli, struct cli_command *c) {
   return CLI_OK;
 }
 
-int cli_int_enable(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
+int cli_enable(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
   if (cli->privilege == PRIVILEGE_PRIVILEGED) return CLI_OK;
 
   if (!cli->enable_password && !cli->enable_callback) {
@@ -515,19 +515,19 @@ int cli_int_enable(struct cli_def *cli, UNUSED(const char *command), UNUSED(char
   return CLI_OK;
 }
 
-int cli_int_disable(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
+int cli_disable(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
   cli_set_privilege(cli, PRIVILEGE_UNPRIVILEGED);
   cli_set_configmode(cli, MODE_EXEC, NULL);
   return CLI_OK;
 }
 
-int cli_int_help(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
+int cli_help(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
   cli_error(cli, "\nCommands available:");
   cli_show_help(cli, cli->commands);
   return CLI_OK;
 }
 
-int cli_int_history(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
+int cli_history(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
   int i;
 
   cli_error(cli, "\nCommand history:");
@@ -538,14 +538,14 @@ int cli_int_history(struct cli_def *cli, UNUSED(const char *command), UNUSED(cha
   return CLI_OK;
 }
 
-int cli_int_quit(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
+int cli_quit(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
   cli_set_privilege(cli, PRIVILEGE_UNPRIVILEGED);
   cli_set_configmode(cli, MODE_EXEC, NULL);
   return CLI_QUIT;
 }
 
-int cli_int_exit(struct cli_def *cli, const char *command, char *argv[], int argc) {
-  if (cli->mode == MODE_EXEC) return cli_int_quit(cli, command, argv, argc);
+int cli_exit(struct cli_def *cli, const char *command, char *argv[], int argc) {
+  if (cli->mode == MODE_EXEC) return cli_quit(cli, command, argv, argc);
 
   if (cli->mode > MODE_CONFIG)
     cli_set_configmode(cli, MODE_CONFIG, NULL);
@@ -580,15 +580,15 @@ struct cli_def *cli_init() {
   }
   cli->telnet_protocol = 1;
 
-  cli_register_command(cli, 0, "help", cli_int_help, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Show available commands");
-  cli_register_command(cli, 0, "quit", cli_int_quit, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Disconnect");
-  cli_register_command(cli, 0, "logout", cli_int_quit, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Disconnect");
-  cli_register_command(cli, 0, "exit", cli_int_exit, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Exit from current mode");
-  cli_register_command(cli, 0, "history", cli_int_history, PRIVILEGE_UNPRIVILEGED, MODE_ANY,
+  cli_register_command(cli, 0, "help", cli_help, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Show available commands");
+  cli_register_command(cli, 0, "quit", cli_quit, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Disconnect");
+  cli_register_command(cli, 0, "logout", cli_quit, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Disconnect");
+  cli_register_command(cli, 0, "exit", cli_exit, PRIVILEGE_UNPRIVILEGED, MODE_ANY, "Exit from current mode");
+  cli_register_command(cli, 0, "history", cli_history, PRIVILEGE_UNPRIVILEGED, MODE_ANY,
                        "Show a list of previously run commands");
-  cli_register_command(cli, 0, "enable", cli_int_enable, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
+  cli_register_command(cli, 0, "enable", cli_enable, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
                        "Turn on privileged commands");
-  cli_register_command(cli, 0, "disable", cli_int_disable, PRIVILEGE_PRIVILEGED, MODE_EXEC,
+  cli_register_command(cli, 0, "disable", cli_disable, PRIVILEGE_PRIVILEGED, MODE_EXEC,
                        "Turn off privileged commands");
 
   c = cli_register_command(cli, 0, "configure", 0, PRIVILEGE_PRIVILEGED, MODE_EXEC, "Enter configuration mode");
@@ -3141,4 +3141,33 @@ void cli_unregister_all_commands(struct cli_def *cli) {
 
 void cli_unregister_all_filters(struct cli_def *cli) {
   cli_unregister_tree(cli, cli->commands, CLI_FILTER_COMMAND);
+}
+
+/*
+ * Several routines were declared as internal, but would be useful for external use also
+ * Rename them so they can be exposed, but have original routines simply call the 'public' ones
+ */
+ 
+int cli_int_quit(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
+  return cli_quit(cli, command, argv, argc);
+}
+
+int cli_int_help(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
+  return cli_help(cli, command, argv, argc);
+}
+
+int cli_int_history(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
+  return cli_history(cli, command, argv, argc);
+}
+
+int cli_int_exit(struct cli_def *cli, const char *command, char *argv[], int argc) {
+  return cli_exit(cli, command, argv, argc);
+}
+
+int cli_int_enable(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
+  return cli_enable(cli, command, argv, argc);
+}
+
+int cli_int_disable(struct cli_def *cli, UNUSED(const char *command), UNUSED(char *argv[]), UNUSED(int argc)) {
+  return cli_disable(cli, command, argv, argc);
 }

--- a/libcli.h
+++ b/libcli.h
@@ -81,6 +81,7 @@ struct cli_def {
   void *user_context;
   struct cli_optarg_pair *found_optargs;
   int transient_mode;
+  int disallow_buildmode;
   struct cli_pipeline *pipeline;
   struct cli_buildmode *buildmode;
 };

--- a/libcli.h
+++ b/libcli.h
@@ -247,6 +247,18 @@ void cli_unregister_all_filters(struct cli_def *cli);
 void cli_unregister_all_commands(struct cli_def *cli);
 void cli_unregister_all(struct cli_def *cli, struct cli_command *command);
 
+/*
+ * Expose some previous internal routines.  Just in case someone was using those 
+ * with an explicit reference, the original routines (cli_int_*) internally point
+ * to the newly public routines.
+ */
+int cli_help(struct cli_def *cli, const char *command, char *argv[], int argc) ;
+int cli_history(struct cli_def *cli, const char *command, char *argv[], int argc) ;
+int cli_exit(struct cli_def *cli, const char *command, char *argv[], int argc) ;
+int cli_quit(struct cli_def *cli, const char *command, char *argv[], int argc) ;
+int cli_enable(struct cli_def *cli, const char *command, char *argv[], int argc) ;
+int cli_disable(struct cli_def *cli, const char *command, char *argv[], int argc) ;
+
 #ifdef __cplusplus
 }
 #endif

--- a/libcli.spec
+++ b/libcli.spec
@@ -75,6 +75,7 @@ rm -rf $RPM_BUILD_ROOT
 - Fix coerner case in buildmode where no extra settings specified
   and user enters 'exit'
 - Rename buildmode 'exit' command to 'execute' based on feedback
+
 * Tue Jul 23 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.0-2
 - Fix spec file and rpm build issues
 - Fix 2 memory leaks (tab completion and help formatting)

--- a/libcli.spec
+++ b/libcli.spec
@@ -74,6 +74,7 @@ rm -rf $RPM_BUILD_ROOT
   old command pointing to new command for backward compatability
 - Fix coerner case in buildmode where no extra settings specified
   and user enters 'exit'
+- Rename buildmode 'exit' command to 'execute' based on feedback
 * Tue Jul 23 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.0-2
 - Fix spec file and rpm build issues
 - Fix 2 memory leaks (tab completion and help formatting)

--- a/libcli.spec
+++ b/libcli.spec
@@ -1,7 +1,7 @@
-Version: 1.10.0
+Version: 1.10.1
 Summary: Cisco-like telnet command-line library
 Name: libcli
-Release: 2
+Release: 1
 License: LGPL
 Group: Library/Communication
 Source: %{name}-%{version}.tar.gz
@@ -67,6 +67,11 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 
 %changelog
+* Wed Jul 30 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.1-1
+- Bump version
+- Renamed cli_int_[help|history|exit|quit|enable|disable] to
+  same routine minut '_int_', and exposed in libcli.h.  Retained
+  old command pointing to new command for backward compatability
 * Tue Jul 23 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.0-2
 - Fix spec file and rpm build issues
 - Fix 2 memory leaks (tab completion and help formatting)

--- a/libcli.spec
+++ b/libcli.spec
@@ -67,6 +67,13 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 
 %changelog
+* Wed Aug 7 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.1-1
+- Rework how help text is formatted to allow for word wrapping
+  and embedded newlines
+- Rework optarg help text to allow the optarg to have specific
+  help messages based on user input - look at clitest at the
+  'shape' optarg examples.
+
 * Wed Jul 30 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.1-1
 - Bump version
 - Renamed cli_int_[help|history|exit|quit|enable|disable] to

--- a/libcli.spec
+++ b/libcli.spec
@@ -72,6 +72,8 @@ rm -rf $RPM_BUILD_ROOT
 - Renamed cli_int_[help|history|exit|quit|enable|disable] to
   same routine minut '_int_', and exposed in libcli.h.  Retained
   old command pointing to new command for backward compatability
+- Fix coerner case in buildmode where no extra settings specified
+  and user enters 'exit'
 * Tue Jul 23 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.0-2
 - Fix spec file and rpm build issues
 - Fix 2 memory leaks (tab completion and help formatting)

--- a/libcli.spec
+++ b/libcli.spec
@@ -70,6 +70,8 @@ rm -rf $RPM_BUILD_ROOT
 * Wed Aug 7 2019 Rob Sanders <rsanders@forcepoint.com> 1.10.1-1
 - Rework how help text is formatted to allow for word wrapping
   and embedded newlines
+- Rework how 'buildmode' is show for help messages so it uses
+  a single '*' as the first char of the help text.
 - Rework optarg help text to allow the optarg to have specific
   help messages based on user input - look at clitest at the
   'shape' optarg examples.


### PR DESCRIPTION
Several bug fixes, but major work on how 'help' messages are display. Biggest change for 'legacy' is that the help messages for commands are now wrapped (default 80 cols), and my contain embedded cr/lf