### PR TITLE
Rework slightly extended help - new comand for cleaner use

### DIFF
--- a/clitest.c
+++ b/clitest.c
@@ -376,8 +376,10 @@ void run_child(int x) {
   cli_register_optarg(c, "__check1__", CLI_CMD_SPOT_CHECK, PRIVILEGE_UNPRIVILEGED, MODE_EXEC, NULL, NULL,
                       check1_validator, NULL);
   cli_register_optarg(c, "shape", CLI_CMD_ARGUMENT | CLI_CMD_ALLOW_BUILDMODE, PRIVILEGE_UNPRIVILEGED, MODE_EXEC,
-                      "Specify shape(shows subtext on help)\ttriangle\tSpecify a triangle\trectangle\tspecify a rectangle", shape_completor, shape_validator,
-                      shape_transient_eval);
+                      "Specify shape(shows subtext on help)", shape_completor, shape_validator, shape_transient_eval);
+  cli_optarg_addhelp(c, "shape", "triangle", "specify a triangle");
+  cli_optarg_addhelp(c, "shape", "rectangle", "pecify a rectangle");
+
   cli_register_optarg(c, "side_1", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_TRIANGLE,
                       "Specify side 1 length", NULL, side_length_validator, NULL);
   cli_register_optarg(c, "side_1", CLI_CMD_ARGUMENT, PRIVILEGE_UNPRIVILEGED, MODE_POLYGON_RECTANGLE,

--- a/libcli.h
+++ b/libcli.h
@@ -238,6 +238,7 @@ int cli_register_optarg(struct cli_command *cmd, const char *name, int flags, in
                         int (*get_completions)(struct cli_def *cli, const char *, const char *, struct cli_comphelp *),
                         int (*validator)(struct cli_def *cli, const char *, const char *),
                         int (*transient_mode)(struct cli_def *, const char *, const char *));
+int cli_optarg_addhelp(struct cli_command *cmd, const char *optargname, const char *helpname, const char *helptext);
 char *cli_find_optarg_value(struct cli_def *cli, char *name, char *find_after);
 struct cli_optarg_pair *cli_get_all_found_optargs(struct cli_def *cli);
 int cli_unregister_optarg(struct cli_command *cmd, const char *name);


### PR DESCRIPTION
Reworked internals of parsing help messages slightly on how 'helpstring' gets broken apart.
Added new method to add 'help' text to an existing optarg.  Syntax is slightly different than existing API calls, but did not want to alter cli_register_optarg() api to change return value.