### PR TITLE
Fix cli_init declaration when -Werror=strict-prototypes is used

### DIFF
--- a/libcli.h
+++ b/libcli.h
@@ -186,7 +186,7 @@ struct cli_buildmode {
   char *mode_text;
 };
 
-struct cli_def *cli_init();
+struct cli_def *cli_init(void);
 int cli_done(struct cli_def *cli);
 struct cli_command *cli_register_command(struct cli_def *cli, struct cli_command *parent, const char *command,
                                          int (*callback)(struct cli_def *, const char *, char **, int), int privilege,


### PR DESCRIPTION
The following error appears if the file libcli.h is included in a source
file compiled with strict-prototypes:

libcli/libcli.h:189:8: error: function declaration isn't a prototype [-Werror=strict-prototypes]
  189 | struct cli_def *cli_init();

Setting void as parameter solves the issue.