### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
+os: linux
+arch:
+ - amd64
+ - ppc64le
 language: c
 script: make


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
