### PR TITLE
Regular callback improvements

### DIFF
--- a/libcli.c
+++ b/libcli.c
@@ -1114,6 +1114,7 @@ int cli_loop(struct cli_def *cli, int sockfd) {
 
   // Set the last action now so we don't time immediately
   if (cli->idle_timeout) time(&cli->last_action);
+  if (cli->regular_callback) time(&cli->last_regular);
 
   // Start off in unprivileged mode
   cli_set_privilege(cli, PRIVILEGE_UNPRIVILEGED);
@@ -1186,6 +1187,16 @@ int cli_loop(struct cli_def *cli, int sockfd) {
         cli->showprompt = 0;
       }
 
+      if (cli->regular_callback) {
+        if (time(NULL) - cli->last_regular >= cli->timeout_tm.tv_sec) {
+          if (cli->regular_callback(cli) != CLI_OK) {
+            l = -1;
+            break;
+          }
+          time(&cli->last_regular);
+        }
+      }
+
       if ((sr = cli_socket_wait(sockfd, &tm)) < 0) {
         if (errno == EINTR) continue;
         perror(CLI_SOCKET_WAIT_PERROR);
@@ -1194,12 +1205,6 @@ int cli_loop(struct cli_def *cli, int sockfd) {
       }
 
       if (sr == 0) {
-        // Timeout every second
-        if (cli->regular_callback && cli->regular_callback(cli) != CLI_OK) {
-          l = -1;
-          break;
-        }
-
         if (cli->idle_timeout) {
           if (time(NULL) - cli->last_action >= cli->idle_timeout) {
             if (cli->idle_timeout_callback) {

--- a/libcli.h
+++ b/libcli.h
@@ -78,6 +78,7 @@ struct cli_def {
   time_t idle_timeout;
   int (*idle_timeout_callback)(struct cli_def *);
   time_t last_action;
+  time_t last_regular;
   int telnet_protocol;
   void *user_context;
   struct cli_optarg_pair *found_optargs;


### PR DESCRIPTION
Regular callback is called only if there's no input from the client during the regular interval. Fix by calling the callback when the interval expires, regardless of input from the client.