### PR TITLE
Change cli_loop completor code to be case sensitive.

### DIFF
--- a/libcli.c
+++ b/libcli.c
@@ -1513,7 +1513,7 @@ int cli_loop(struct cli_def *cli, int sockfd) {
               k = 0;
 
             for (j = 0; (j < k) && (j < (int)strlen(wptr)); j++) {
-              if (strncasecmp(tptr + j, wptr + j, 1)) break;
+              if (strncmp(tptr + j, wptr + j, 1)) break;
             }
             k = j;
           }


### PR DESCRIPTION
Fixing cli_loop() completor code to be case sensitive - affects primarily the opt/arg parsing.  Commands are not properly differentiating between commands that differ only in case at this point.